### PR TITLE
Add hd parameter to limit to host domain for google oauth2

### DIFF
--- a/lib/torii/providers/google-oauth2.js
+++ b/lib/torii/providers/google-oauth2.js
@@ -13,7 +13,7 @@ var GoogleOauth2 = Oauth2.extend({
 
   // additional params that this provider requires
   requiredUrlParams: ['state'],
-  optionalUrlParams: ['scope', 'request_visible_actions', 'access_type'],
+  optionalUrlParams: ['scope', 'request_visible_actions', 'access_type', 'hd'],
 
   requestVisibleActions: configurable('requestVisibleActions', ''),
 
@@ -26,7 +26,9 @@ var GoogleOauth2 = Oauth2.extend({
   state: configurable('state', 'STATE'),
 
   redirectUri: configurable('redirectUri',
-                            'http://localhost:8000/oauth2callback')
+                            'http://localhost:8000/oauth2callback'),
+
+  hd: configurable('hd', 'hd')
 });
 
 export default GoogleOauth2;


### PR DESCRIPTION
This closes #121 

I tested this out initially by extending the default google-ouath2 provider and it worked flawlessly. Let me know if this needs fixing and I will add it :)