### PR TITLE
Pass options from provider open() to popup open()

### DIFF
--- a/lib/torii/providers/facebook-oauth2.js
+++ b/lib/torii/providers/facebook-oauth2.js
@@ -19,8 +19,8 @@ export default Oauth2.extend({
     return this._super();
   }),
 
-  open: function() {
-    return this._super().then(function(authData){
+  open: function(options) {
+    return this._super(options).then(function(authData){
       if (authData.authorizationCode && authData.authorizationCode === '200') {
         // indication that the user hit 'cancel', not 'ok'
         throw 'User canceled authorization';

--- a/lib/torii/providers/oauth1.js
+++ b/lib/torii/providers/oauth1.js
@@ -25,11 +25,11 @@ var Oauth1 = Provider.extend({
     return requestTokenUri;
   },
 
-  open: function(){
+  open: function(options){
     var name        = this.get('name'),
         url         = this.buildRequestTokenUrl();
 
-    return this.get('popup').open(url, ['code']).then(function(authData){
+    return this.get('popup').open(url, ['code'], options).then(function(authData){
       authData.provider = name;
       return authData;
     });

--- a/lib/torii/providers/oauth2-bearer.js
+++ b/lib/torii/providers/oauth2-bearer.js
@@ -13,13 +13,13 @@ var Oauth2Bearer = Provider.extend({
    * If there was an error or the user either canceled the authorization or
    * closed the popup window, the promise rejects.
    */
-  open: function(){
+  open: function(options){
     var name        = this.get('name'),
         url         = this.buildUrl(),
         redirectUri = this.get('redirectUri'),
         responseParams = this.get('responseParams');
 
-    return this.get('popup').open(url, responseParams).then(function(authData){
+    return this.get('popup').open(url, responseParams, options).then(function(authData){
       var missingResponseParams = [];
 
       responseParams.forEach(function(param){

--- a/lib/torii/providers/oauth2-code.js
+++ b/lib/torii/providers/oauth2-code.js
@@ -113,13 +113,13 @@ var Oauth2 = Provider.extend({
    * If there was an error or the user either canceled the authorization or
    * closed the popup window, the promise rejects.
    */
-  open: function(){
+  open: function(options){
     var name        = this.get('name'),
         url         = this.buildUrl(),
         redirectUri = this.get('redirectUri'),
         responseParams = this.get('responseParams');
 
-    return this.get('popup').open(url, responseParams).then(function(authData){
+    return this.get('popup').open(url, responseParams, options).then(function(authData){
       var missingResponseParams = [];
 
       responseParams.forEach(function(param){


### PR DESCRIPTION
Adds passing the options from oauth provider's `.open()` method
to the popup window's `.open()` so that the caller can override
the width and height of the popup.  Currently there are options but
no way to actually set them from outside the library.
