### PR TITLE
use responsetype key for authdata

### DIFF
--- a/lib/torii/providers/oauth2-code.js
+++ b/lib/torii/providers/oauth2-code.js
@@ -117,7 +117,8 @@ var Oauth2 = Provider.extend({
     var name        = this.get('name'),
         url         = this.buildUrl(),
         redirectUri = this.get('redirectUri'),
-        responseParams = this.get('responseParams');
+        responseParams = this.get('responseParams'),
+        responseType = this.get('responseType');
 
     return this.get('popup').open(url, responseParams).then(function(authData){
       var missingResponseParams = [];
@@ -134,7 +135,7 @@ var Oauth2 = Provider.extend({
       }
 
       return {
-        authorizationCode: authData.code,
+        authorizationCode: authData[responseType],
         provider: name,
         redirectUri: redirectUri
       };

--- a/test/tests/integration/providers/facebook-oauth2-test.js
+++ b/test/tests/integration/providers/facebook-oauth2-test.js
@@ -8,7 +8,7 @@ var originalConfiguration = configuration.providers['facebook-oauth2'];
 var opened, mockPopup = {
   open: function(){
     opened = true;
-    return Ember.RSVP.resolve({code:'abc'});
+    return Ember.RSVP.resolve({ code: 'abc' });
   }
 };
 

--- a/test/tests/integration/providers/github-oauth2-test.js
+++ b/test/tests/integration/providers/github-oauth2-test.js
@@ -8,7 +8,7 @@ var originalConfiguration = configuration.providers['github-oauth2'];
 var opened, mockPopup = {
   open: function(){
     opened = true;
-    return Ember.RSVP.resolve({});
+    return Ember.RSVP.resolve({ code: 'test' });
   }
 };
 

--- a/test/tests/integration/providers/google-oauth2-test.js
+++ b/test/tests/integration/providers/google-oauth2-test.js
@@ -12,7 +12,7 @@ module('Google - Integration', {
     mockPopup = {
       open: function(){
         opened = true;
-        return Ember.RSVP.resolve({});
+        return Ember.RSVP.resolve({ code: 'test' });
       }
     };
     container = toriiContainer();
@@ -44,7 +44,7 @@ test("Opens a popup to Google with request_visible_actions", function(){
     ok(
       url.indexOf("request_visible_actions=http%3A%2F%2Fsome-url.com") > -1,
       "request_visible_actions is present" );
-    return Ember.RSVP.resolve({});
+    return Ember.RSVP.resolve({ code: 'test' });
   }
   Ember.run(function(){
     torii.open('google-oauth2');
@@ -58,7 +58,7 @@ test("Opens a popup to Google with access_type parameter", function(){
     ok(
       url.indexOf("access_type=offline") > -1,
       "access_type parameter is present" );
-    return Ember.RSVP.resolve({});
+    return Ember.RSVP.resolve({ code: 'test' });
   }
   Ember.run(function(){
     torii.open('google-oauth2');

--- a/test/tests/integration/providers/linked-in-oauth2-test.js
+++ b/test/tests/integration/providers/linked-in-oauth2-test.js
@@ -8,7 +8,7 @@ var originalConfiguration = configuration.providers['linked-in-oauth2'];
 var opened, mockPopup = {
   open: function(){
     opened = true;
-    return Ember.RSVP.resolve({});
+    return Ember.RSVP.resolve({ code: 'test' });
   }
 };
 


### PR DESCRIPTION
When using openid connect the responsecode is not in `code` but in `id_token`. Which is the same as the `responseType` property. This changes it so it uses the `responseType` value as key for getting a token or code from the `authData`.

Will update the azuread PR after this is pulled in.