### PR TITLE
Ensure that Facebook Connect triggers fbAsyncInit

### DIFF
--- a/lib/torii/providers/facebook-connect.js
+++ b/lib/torii/providers/facebook-connect.js
@@ -22,6 +22,10 @@ function fbLoad(settings){
     $.getScript('//connect.facebook.net/en_US/sdk.js');
   }).then(function(){
     window.fbAsyncInit = original;
+    if (window.fbAsyncInit) {
+      window.fbAsyncInit.hasRun = true;
+      window.fbAsyncInit();
+    }
   });
 
   return fbPromise;


### PR DESCRIPTION
The FB JS SDK executes the function assigned to window.fbAsyncInit like this:

                if (window.fbAsyncInit && !window.fbAsyncInit.hasRun) {
                    window.fbAsyncInit.hasRun = true;
                    h.unguard(window.fbAsyncInit)();
                }

Torii overrides `window.fbAsyncInit` and stashes anything already assigned. But the FB SDK will only ever execute the Torii-overridden version. This commit ensures the originally assigned function is called, and the hasRun flag is set, as it is in the SDK.