### PR TITLE
Fix incorrect `main` entry point script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "torii",
   "version": "0.2.3",
   "description": "A set of clean abstractions for authentication in Ember.js",
-  "main": "dist/commonjs/main.js",
+  "main": "ember-addon/index.js",
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
The `ember-addon.main` path is still needed until https://github.com/ember-cli/ember-cli/pull/3545 is landed in a released version.

This fixes https://github.com/Vestorly/torii/issues/147.