### PR TITLE
Fix popup service for IE8/9.

### DIFF
--- a/lib/torii/services/popup.js
+++ b/lib/torii/services/popup.js
@@ -94,7 +94,7 @@ var Popup = Ember.Object.extend(Ember.Evented, {
       }
 
       var optionsString = stringifyOptions(prepareOptions(options || {}));
-      service.popup = window.open(url, 'torii-auth', optionsString);
+      service.popup = window.open(url, 'torii_auth', optionsString);
 
       if (service.popup && !service.popup.closed) {
         service.popup.focus();

--- a/test/tests/unit/redirect-handler-test.js
+++ b/test/tests/unit/redirect-handler-test.js
@@ -5,7 +5,7 @@ var originalClose = window.close;
 
 module('RedirectHandler - Unit', {
   setup: function(){
-    window.name = 'torii-auth';
+    window.name = 'torii_auth';
     window.opener = {
       name: 'torii-opener',
       postMessage: Ember.K


### PR DESCRIPTION
IE8/9 does not like dashes or spaces in the window name. It causes it to throw an Invalid argument error.

This can be reproduced by running the following in an IE8/9 console. `window.open("http://google.com", "with-a-dash")` fails and `window.open("http://google.com", "with_no_dash")` works as expected.