### PR TITLE
Avoid using `app` in the Ember Addon.

### DIFF
--- a/ember-addon/index.js
+++ b/ember-addon/index.js
@@ -2,10 +2,9 @@
 
 module.exports = {
   name: 'torii',
-  init: function(app) {
+  init: function() {
     this.treePaths.app = '../lib/torii';
     this.treePaths.addon = '../lib/torii';
-    this.app = app;
   },
 
   treeForApp: function treeForApp(tree) {
@@ -24,7 +23,7 @@ module.exports = {
 
     // Use a build-time check to output a warning if Torii is not
     // conigured.
-    var config = this.project.config(this.app.env);
+    var config = this.project.config(proccess.env.EMBER_ENV);
     if (!config.torii) {
       console.warn("Torii is installed but not configured in config/environment.js!");
     } else {
@@ -35,7 +34,7 @@ module.exports = {
         files: ['modules/torii/configuration.js'],
         patterns: [{
           match: /get\(window, 'ENV\.torii'\)/,
-          replacement: 'require("'+this.app.name+'/config/environment")["default"].torii'
+          replacement: 'require("'+this.project.name()+'/config/environment")["default"].torii'
         }]
       });
     }


### PR DESCRIPTION
Reverts https://github.com/Vestorly/torii/pull/162, and removes usage of `this.app`.

`addon.app` is actually set in the Broccoli setup for top-level included addons ([see here](https://github.com/ember-cli/ember-cli/blob/da0f380f6b4149c98148a26e8948eb84aa98bdd0/lib/broccoli/ember-app.js#L272)).

---

`app` is not passed into the Addon `init` method.  It gets the `parent` passed in, which is a `project` instance when the addon is included as a top level dependency, or an `addon` instance if it is a nested addon.

* Instantiation called [here](https://github.com/ember-cli/ember-cli/blob/eb7fa3725e0e6b2b7a968e6f41c043496907e9c1/lib/models/addons-factory.js#L48) from within the `addonsFactory` helper object.
* `AddonDiscovery` is setup [here](https://github.com/ember-cli/ember-cli/blob/da0f380f6b4149c98148a26e8948eb84aa98bdd0/lib/models/project.js#L43) for top-level project addons.
* `AddonDiscovery` is setup [here](https://github.com/ember-cli/ember-cli/blob/da0f380f6b4149c98148a26e8948eb84aa98bdd0/lib/models/addon.js#L61) for addons that are nested under another addon.