### PR TITLE
Do not throw strings.

### DIFF
--- a/lib/torii/lib/query-string.js
+++ b/lib/torii/lib/query-string.js
@@ -40,7 +40,7 @@ export default Ember.Object.extend({
 
     this.optionalUrlParams.forEach(function(param){
       if (this.urlParams.indexOf(param) > -1) {
-        throw "Required parameters cannot also be optional: '" + param + "'";
+        throw new Error("Required parameters cannot also be optional: '" + param + "'");
       }
     }, this);
   },

--- a/lib/torii/providers/facebook-oauth2.js
+++ b/lib/torii/providers/facebook-oauth2.js
@@ -23,7 +23,7 @@ export default Oauth2.extend({
     return this._super().then(function(authData){
       if (authData.authorizationCode && authData.authorizationCode === '200') {
         // indication that the user hit 'cancel', not 'ok'
-        throw 'User canceled authorization';
+        throw new Error('User canceled authorization');
       }
 
       return authData;

--- a/lib/torii/providers/oauth2-bearer.js
+++ b/lib/torii/providers/oauth2-bearer.js
@@ -29,8 +29,8 @@ var Oauth2Bearer = Provider.extend({
       });
 
       if (missingResponseParams.length){
-        throw "The response from the provider is missing " +
-              "these required response params: " + responseParams.join(', ');
+        throw new Error("The response from the provider is missing " +
+              "these required response params: " + responseParams.join(', '));
       }
 
       return {

--- a/lib/torii/providers/oauth2-code.js
+++ b/lib/torii/providers/oauth2-code.js
@@ -130,8 +130,8 @@ var Oauth2 = Provider.extend({
       });
 
       if (missingResponseParams.length){
-        throw "The response from the provider is missing " +
-              "these required response params: " + responseParams.join(', ');
+        throw new Error("The response from the provider is missing " +
+              "these required response params: " + responseParams.join(', '));
       }
 
       return {


### PR DESCRIPTION
When throwing strings, no stack trace is available (making it much
harder to track down these errors from within nested promises).