### PR TITLE
Do not rely on prototype extensions.

### DIFF
--- a/lib/torii/providers/azure-ad-oauth2.js
+++ b/lib/torii/providers/azure-ad-oauth2.js
@@ -1,6 +1,8 @@
 import Oauth2 from 'torii/providers/oauth2-code';
 import {configurable} from 'torii/configuration';
 
+var computed = Ember.computed;
+
 /**
  * This class implements authentication against AzureAD
  * using the OAuth2 authorization flow in a popup window.
@@ -9,9 +11,9 @@ import {configurable} from 'torii/configuration';
 var AzureAdOauth2 = Oauth2.extend({
   name: 'azure-ad-oauth2',
 
-  baseUrl: function() {
+  baseUrl: computed(function() {
     return 'https://login.windows.net/' + this.get('tennantId') + '/oauth2/authorize';
-  }.property(),
+  }),
 
   tennantId: configurable('tennantId', 'common'),
 
@@ -22,9 +24,9 @@ var AzureAdOauth2 = Oauth2.extend({
 
   responseMode: configurable('responseMode', null),
 
-  responseParams: function () {
+  responseParams: computed(function () {
     return [ this.get('responseType') ];
-  }.property(),
+  }),
 
   state: 'STATE',
 

--- a/lib/torii/providers/base.js
+++ b/lib/torii/providers/base.js
@@ -1,5 +1,7 @@
 import requiredProperty from 'torii/lib/required-property';
 
+var computed = Ember.computed;
+
 /**
  * The base class for all torii providers
  * @class BaseProvider
@@ -17,9 +19,9 @@ var Base = Ember.Object.extend({
    * that holds config information for this provider.
    * @property {string} configNamespace
    */
-  configNamespace: function(){
+  configNamespace: computed('name', function(){
     return 'providers.'+this.get('name');
-  }.property('name')
+  })
 
 });
 

--- a/lib/torii/providers/facebook-connect.js
+++ b/lib/torii/providers/facebook-connect.js
@@ -8,6 +8,7 @@
 import Provider from 'torii/providers/base';
 import {configurable} from 'torii/configuration';
 
+var on = Ember.on;
 var fbPromise;
 
 function fbLoad(settings){
@@ -82,9 +83,9 @@ var Facebook = Provider.extend({
   // Load Facebook's script eagerly, so that the window.open
   // in FB.login will be part of the same JS frame as the
   // click itself.
-  loadFbLogin: function(){
+  loadFbLogin: on('init', function(){
     fbLoad( this.settings() );
-  }.on('init')
+  })
 
 });
 

--- a/lib/torii/providers/oauth2-code.js
+++ b/lib/torii/providers/oauth2-code.js
@@ -3,6 +3,8 @@ import {configurable} from 'torii/configuration';
 import QueryString from 'torii/lib/query-string';
 import requiredProperty from 'torii/lib/required-property';
 
+var computed = Ember.computed;
+
 function currentUrl(){
   return [window.location.protocol,
           "//",
@@ -84,9 +86,9 @@ var Oauth2 = Provider.extend({
   */
   responseParams: requiredProperty(),
 
-  redirectUri: function(){
+  redirectUri: computed(function(){
     return currentUrl();
-  }.property(),
+  }),
 
   buildQueryString: function(){
     var requiredParams = this.get('requiredUrlParams'),

--- a/lib/torii/services/popup.js
+++ b/lib/torii/services/popup.js
@@ -1,5 +1,7 @@
 import ParseQueryString from 'torii/lib/parse-query-string';
 
+var on = Ember.on;
+
 var postMessageFixed;
 var postMessageDomain = window.location.protocol+'//'+window.location.host;
 var postMessagePrefix = "__torii_message:";
@@ -151,9 +153,9 @@ var Popup = Ember.Object.extend(Ember.Evented, {
     }, 35);
   },
 
-  stopPolling: function(){
+  stopPolling: on('didClose', function(){
     Ember.run.cancel(this.polling);
-  }.on('didClose'),
+  }),
 
 
 });

--- a/lib/torii/session.js
+++ b/lib/torii/session.js
@@ -1,5 +1,8 @@
 import createStateMachine from 'torii/session/state-machine';
 
+var computed = Ember.computed;
+var on = Ember.on;
+
 function lookupAdapter(container, authenticationType){
   var adapter = container.lookup('torii-adapter:'+authenticationType);
   if (!adapter) {
@@ -11,18 +14,18 @@ function lookupAdapter(container, authenticationType){
 var Session = Ember.ObjectProxy.extend({
   state: null,
 
-  stateMachine: function(){
+  stateMachine: computed(function(){
     return createStateMachine(this);
-  }.property(),
+  }),
 
-  setupStateProxy: function(){
+  setupStateProxy: on('init', function(){
     var sm    = this.get('stateMachine'),
         proxy = this;
     sm.on('didTransition', function(){
       proxy.set('content', sm.state);
       proxy.set('currentStateName', sm.currentStateName);
     });
-  }.on('init'),
+  }),
 
   // Make these properties one-way.
   setUnknownProperty: Ember.K,

--- a/test/index.html
+++ b/test/index.html
@@ -9,6 +9,12 @@
 
     <link rel="stylesheet" href='../bower_components/qunit/qunit/qunit.css'>
 
+    <script>
+      window.EmberENV = {
+        EXTEND_PROTOTYPES: false
+      };
+    </script>
+
     <script src='../bower_components/loader/loader.js'></script>
     <script src='../bower_components/jquery/dist/jquery.js'></script>
     <script src='../bower_components/handlebars/handlebars.js'></script>


### PR DESCRIPTION
* Change usage of `.property()` to `Ember.computed`.
* Change usage of `.on()` to `Ember.on`.
* Update test harness to disable prototype extensions.