### PR TITLE
Add google-oauth2-bearer provider

### DIFF
--- a/lib/torii/bootstrap/torii.js
+++ b/lib/torii/bootstrap/torii.js
@@ -1,6 +1,7 @@
 import Torii from 'torii/torii';
 import LinkedInOauth2Provider from 'torii/providers/linked-in-oauth2';
 import GoogleOauth2Provider from 'torii/providers/google-oauth2';
+import GoogleOauth2BearerProvider from 'torii/providers/google-oauth2-bearer';
 import FacebookConnectProvider from 'torii/providers/facebook-connect';
 import FacebookOauth2Provider from 'torii/providers/facebook-oauth2';
 import ApplicationAdapter from 'torii/adapters/application';
@@ -15,6 +16,7 @@ export default function(container){
   container.register('torii:main', Torii);
   container.register('torii-provider:linked-in-oauth2', LinkedInOauth2Provider);
   container.register('torii-provider:google-oauth2', GoogleOauth2Provider);
+  container.register('torii-provider:google-oauth2-bearer', GoogleOauth2BearerProvider);
   container.register('torii-provider:facebook-connect', FacebookConnectProvider);
   container.register('torii-provider:facebook-oauth2', FacebookOauth2Provider);
   container.register('torii-provider:twitter', TwitterProvider);

--- a/lib/torii/providers/google-oauth2-bearer.js
+++ b/lib/torii/providers/google-oauth2-bearer.js
@@ -1,0 +1,30 @@
+/**
+ * This class implements authentication against google
+ * using the client-side OAuth2 authorization flow in a popup window.
+ */
+
+import Oauth2Bearer from 'torii/providers/oauth2-bearer';
+import {configurable} from 'torii/configuration';
+
+var GoogleOauth2Bearer = Oauth2Bearer.extend({
+
+  name:    'google-oauth2-bearer',
+  baseUrl: 'https://accounts.google.com/o/oauth2/auth',
+
+  // additional params that this provider requires
+  requiredUrlParams: ['state'],
+  optionalUrlParams: ['scope', 'request_visible_actions'],
+
+  requestVisibleActions: configurable('requestVisibleActions', ''),
+
+  responseParams: ['access_token'],
+
+  scope: configurable('scope', 'email'),
+
+  state: configurable('state', 'STATE'),
+
+  redirectUri: configurable('redirectUri',
+                            'http://localhost:8000/oauth2callback')
+});
+
+export default GoogleOauth2Bearer;

--- a/test/tests/integration/providers/google-oauth2-bearer-test.js
+++ b/test/tests/integration/providers/google-oauth2-bearer-test.js
@@ -1,0 +1,53 @@
+var torii, container;
+
+import toriiContainer from 'test/helpers/torii-container';
+import configuration from 'torii/configuration';
+
+var originalConfiguration = configuration.providers['google-oauth2-bearer'];
+
+var opened, mockPopup;
+
+module('Google Bearer- Integration', {
+  setup: function(){
+    mockPopup = {
+      open: function(){
+        opened = true;
+        return Ember.RSVP.resolve({ access_token: 'test' });
+      }
+    };
+    container = toriiContainer();
+    container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
+    container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
+
+    torii = container.lookup("torii:main");
+    configuration.providers['google-oauth2-bearer'] = {apiKey: 'dummy'};
+  },
+  teardown: function(){
+    opened = false;
+    configuration.providers['google-oauth2-bearer'] = originalConfiguration;
+    Ember.run(container, 'destroy');
+  }
+});
+
+test("Opens a popup to Google", function(){
+  expect(1);
+  Ember.run(function(){
+    torii.open('google-oauth2-bearer').finally(function(){
+      ok(opened, "Popup service is opened");
+    });
+  });
+});
+
+test("Opens a popup to Google with request_visible_actions", function(){
+  expect(1);
+  configuration.providers['google-oauth2-bearer'].requestVisibleActions = "http://some-url.com";
+  mockPopup.open = function(url){
+    ok(
+      url.indexOf("request_visible_actions=http%3A%2F%2Fsome-url.com") > -1,
+      "request_visible_actions is present" );
+    return Ember.RSVP.resolve({ access_token: 'test' });
+  }
+  Ember.run(function(){
+    torii.open('google-oauth2-bearer');
+  });
+});

--- a/test/tests/unit/providers/google-oauth2-bearer-test.js
+++ b/test/tests/unit/providers/google-oauth2-bearer-test.js
@@ -1,0 +1,39 @@
+var provider;
+
+import configuration from 'torii/configuration';
+
+import GoogleBearerProvider from 'torii/providers/google-oauth2-bearer';
+
+module('Unit - GoogleAuth2BearerProvider', {
+  setup: function(){
+    configuration.providers['google-oauth2-bearer'] = {};
+    provider = new GoogleBearerProvider();
+  },
+  teardown: function(){
+    Ember.run(provider, 'destroy');
+    configuration.providers['google-oauth2-bearer'] = {};
+  }
+});
+
+test("Provider requires an apiKey", function(){
+  configuration.providers['google-oauth2-bearer'] = {};
+  throws(function(){
+    provider.buildUrl();
+  }, /Expected configuration value providers.google-oauth2-bearer.apiKey to be defined!/);
+});
+
+test("Provider generates a URL with required config", function(){
+  configuration.providers['google-oauth2-bearer'] = {
+    apiKey: 'abcdef'
+  };
+
+  var expectedUrl = provider.get('baseUrl') + '?' + 'response_type=token' +
+          '&client_id=' + 'abcdef' +
+          '&redirect_uri=' + encodeURIComponent(provider.get('redirectUri')) +
+          '&state=STATE' +
+          '&scope=email';
+
+  equal(provider.buildUrl(),
+        expectedUrl,
+        'generates the correct URL');
+});


### PR DESCRIPTION
This PR adds the google-oauth2-bearer provider, which allows Torii users to utilize the client-side OAuth flow outlined here: https://developers.google.com/accounts/docs/OAuth2UserAgent

I originally worked with @rwjblue to get this working in a dummy application before extracting it into a PR. There is quite a bit of duplication between the `google-oauth2-bearer` and `google-oauth2` providers and we discussed creating a mixin to remove the duplication but weren't sure what the desired approach would be. 

The primary difference with the client-side flow above and the server-side flow (https://developers.google.com/accounts/docs/OAuth2WebServer) is the client-side flow immediately grants the consuming application an `access_token` rather than granting an `authorization_code` which is then exchanged for an `access_token`.

Please let me know if there are any thoughts / desired changes on this PR. Thanks for the great library :+1: 