### PR TITLE
Facebook-connect provider SDK version bump, configuration options and token expiration

### DIFF
--- a/lib/torii/providers/facebook-connect.js
+++ b/lib/torii/providers/facebook-connect.js
@@ -14,12 +14,14 @@ function fbLoad(settings){
   if (fbPromise) { return fbPromise; }
 
   var original = window.fbAsyncInit;
+  var locale = settings.locale;
+  delete settings.locale;
   fbPromise = new Ember.RSVP.Promise(function(resolve, reject){
     window.fbAsyncInit = function(){
       FB.init(settings);
       Ember.run(null, resolve);
     };
-    $.getScript('//connect.facebook.net/en_US/sdk.js');
+    $.getScript('//connect.facebook.net/' + locale + '/sdk.js');
   }).then(function(){
     window.fbAsyncInit = original;
     if (window.fbAsyncInit) {
@@ -46,16 +48,21 @@ function fbLogin(scope){
 function fbNormalize(response){
   return {
     userId: response.userID,
-    accessToken: response.accessToken
+    accessToken: response.accessToken,
+    expiresIn: response.expiresIn
   };
 }
 
 var Facebook = Provider.extend({
 
-  // Required settings:
+  // Facebook connect SDK settings:
   name:  'facebook-connect',
   scope: configurable('scope', 'email'),
   appId: configurable('appId'),
+  version: configurable('version', 'v2.2'),
+  xfbml: configurable('xfbml', false),
+  channelUrl: configurable('channelUrl', null),
+  locale: configurable('locale', 'en_US'),
 
   // API:
   //
@@ -73,9 +80,11 @@ var Facebook = Provider.extend({
     return {
       status: true,
       cookie: true,
-      xfbml: false,
-      version: 'v2.0',
-      appId: this.get('appId')
+      xfbml: this.get('xfbml'),
+      version: this.get('version'),
+      appId: this.get('appId'),
+      channelUrl: this.get('channelUrl'),
+      locale: this.get('locale')
     };
   },
 


### PR DESCRIPTION
#### SDK version
Bumped to v2.2. 

#### Configuration options
I added ability to configure SDK externally with next optional params: version (default to v2.2), xfbml, channelUrl, locale (default to 'en_US')

#### Access token expiration
I added expiresIn to a normalized response.