### PR TITLE
Allow to set `scope` and `stripe_landing` for stripe-connect

### DIFF
--- a/lib/torii/providers/stripe-connect.js
+++ b/lib/torii/providers/stripe-connect.js
@@ -7,10 +7,12 @@ export default Oauth2.extend({
 
   // additional url params that this provider requires
   requiredUrlParams: [],
+  optionalUrlParams: ['stripe_landing'],
 
   responseParams: ['code'],
 
-  scope: 'read_write',
+  scope: configurable('scope', 'read_write'),
+  stripeLanding: configurable('stripeLanding', ''),
 
   redirectUri: configurable('redirectUri', function() {
     // A hack that allows redirectUri to be configurable

--- a/test/tests/integration/providers/stripe-connect-test.js
+++ b/test/tests/integration/providers/stripe-connect-test.js
@@ -35,3 +35,31 @@ test("Opens a popup to Stripe", function(){
     });
   });
 });
+
+test("Opens a popup to Stripe with the scope parameter", function(){
+  expect(1);
+  configuration.providers['stripe-connect'].scope = "read_only";
+  mockPopup.open = function(url){
+    ok(
+      url.indexOf("scope=read_only") > -1,
+      "scope is set from config" );
+    return Ember.RSVP.resolve({ code: 'test' });
+  }
+  Ember.run(function(){
+    torii.open('stripe-connect');
+  });
+});
+
+test("Opens a popup to Stripe with the stripe_landing parameter", function(){
+  expect(1);
+  configuration.providers['stripe-connect'].stripeLanding = "login";
+  mockPopup.open = function(url){
+    ok(
+      url.indexOf("stripe_landing=login") > -1,
+      "stripe_landing is set from config" );
+    return Ember.RSVP.resolve({ code: 'test' });
+  }
+  Ember.run(function(){
+    torii.open('stripe-connect');
+  });
+});


### PR DESCRIPTION
This allows `scope` and `stripe_landing` (https://stripe.com/docs/connect/reference) to be set in the stripe-connect's config.