### PR TITLE
Make redirect_uri optional for oauth2 providers

### DIFF
--- a/lib/torii/providers/oauth2-code.js
+++ b/lib/torii/providers/oauth2-code.js
@@ -42,7 +42,7 @@ var Oauth2 = Provider.extend({
    *
    * @property {array} requiredUrlParams
    */
-  requiredUrlParams: ['response_type', 'client_id', 'redirect_uri'],
+  requiredUrlParams: ['response_type', 'client_id'],
 
   /**
    * Parameters that may be included in the 3rd-party provider's url that we build.
@@ -50,7 +50,7 @@ var Oauth2 = Provider.extend({
    *
    * @property {array} optionalUrlParams
    */
-  optionalUrlParams: ['scope'],
+  optionalUrlParams: ['scope', 'redirect_uri'],
 
   /**
    * The base url for the 3rd-party provider's OAuth2 flow (example: 'https://github.com/login/oauth/authorize')

--- a/test/tests/unit/providers/oauth2-code-test.js
+++ b/test/tests/unit/providers/oauth2-code-test.js
@@ -50,6 +50,22 @@ test("Provider requires an apiKey", function(){
   }, /Expected configuration value providers.mock-oauth2.apiKey to be defined!/);
 });
 
+test("Provider does not require a redirectUri", function(){
+  configuration.providers['mock-oauth2'] = { apiKey: 'dummyKey' }
+  provider.redirectUri = null;
+
+  var error;
+
+  try {
+    provider.buildUrl();
+    error = false;
+  } catch(e) {
+    error = e;
+  }
+
+  ok(error === false, 'should not throw an error, but "' + error + '" was thrown');
+});
+
 test("Provider generates a URL with required config", function(){
   configuration.providers['mock-oauth2'] = {
     apiKey: 'dummyKey'


### PR DESCRIPTION
According to the spec the redirect_uri param is optional: https://tools.ietf.org/html/rfc6749#section-4.1.1

Currently a lot of tests fail because the GET params in the generated urls have switched places (`redirect_uri` has moved to the end of the url with the other optional params).

Before fixing the tests I'd like to get some feedback on these questions:

* Is the change legit? :smiley: 
* I would also remove the default value for `redirectUri`, but that could be a breaking change.. WDYT?
* Do any of the included adapters that inherit from `oauth2-code` need the old behaviour?

Thanks!