### PR TITLE
wait a bit to receive postMessage in parent window. 

### DIFF
--- a/lib/torii/services/popup.js
+++ b/lib/torii/services/popup.js
@@ -110,8 +110,8 @@ var Popup = Ember.Object.extend(Ember.Evented, {
         // If we don't receive a message before the timeout, we fail. Normally,
         // the message will be received and the window will close immediately.
         service.timeout = Ember.run.later(service, function() {
-          reject(new Error("Authorization never received authentication message."));
-        }, 5*1000);
+          reject(new Error("Popup was closed, authorization was denied, or a authentication message otherwise not received before the window closed."));
+        }, 100);
       });
 
       Ember.$(window).on('message.torii', function(event){
@@ -119,7 +119,9 @@ var Popup = Ember.Object.extend(Ember.Evented, {
         var toriiMessage = readToriiMessage(message);
         if (toriiMessage) {
           var data = parseMessage(toriiMessage, keys);
-          resolve(data);
+          Ember.run(function() {
+            resolve(data);
+          });
         }
       });
 

--- a/lib/torii/services/popup.js
+++ b/lib/torii/services/popup.js
@@ -107,8 +107,11 @@ var Popup = Ember.Object.extend(Ember.Evented, {
       }
 
       service.one('didClose', function(){
-        reject(new Error(
-          'Popup was closed or authorization was denied'));
+        // If we don't receive a message before the timeout, we fail. Normally,
+        // the message will be received and the window will close immediately.
+        service.timeout = Ember.run.later(service, function() {
+          reject(new Error("Authorization never received authentication message."));
+        }, 5*1000);
       });
 
       Ember.$(window).on('message.torii', function(event){
@@ -125,6 +128,7 @@ var Popup = Ember.Object.extend(Ember.Evented, {
     }).finally(function(){
       // didClose will reject this same promise, but it has already resolved.
       service.close();
+      service.clearTimeout();
       window.name = oldName;
       Ember.$(window).off('message.torii');
     });
@@ -151,6 +155,12 @@ var Popup = Ember.Object.extend(Ember.Evented, {
       this.pollPopup();
       this.schedulePolling();
     }, 35);
+  },
+
+  // Clear the timeout, in case it hasn't fired.
+  clearTimeout: function(){
+    Ember.run.cancel(this.timeout);
+    this.timeout = null;
   },
 
   stopPolling: on('didClose', function(){


### PR DESCRIPTION
Instead of immediately failing when window is closed; wait for a few seconds to receive the message from postMessage; fixes #111.

I found this necessary at least on Chrome Canary and using the twitter provider.
