### PR TITLE
Allow to set `approval_prompt` for google-oauth2

### DIFF
--- a/lib/torii/providers/google-oauth2.js
+++ b/lib/torii/providers/google-oauth2.js
@@ -13,7 +13,7 @@ var GoogleOauth2 = Oauth2.extend({
 
   // additional params that this provider requires
   requiredUrlParams: ['state'],
-  optionalUrlParams: ['scope', 'request_visible_actions', 'access_type'],
+  optionalUrlParams: ['scope', 'request_visible_actions', 'access_type', 'approval_prompt'],
 
   requestVisibleActions: configurable('requestVisibleActions', ''),
 
@@ -24,6 +24,8 @@ var GoogleOauth2 = Oauth2.extend({
   scope: configurable('scope', 'email'),
 
   state: configurable('state', 'STATE'),
+
+  approvalPrompt: configurable('approvalPrompt', 'auto'),
 
   redirectUri: configurable('redirectUri',
                             'http://localhost:8000/oauth2callback')

--- a/test/tests/unit/providers/google-oauth2-test.js
+++ b/test/tests/unit/providers/google-oauth2-test.js
@@ -24,14 +24,16 @@ test("Provider requires an apiKey", function(){
 
 test("Provider generates a URL with required config", function(){
   configuration.providers['google-oauth2'] = {
-    apiKey: 'abcdef'
+    apiKey: 'abcdef',
+    approvalPrompt: 'force'
   };
 
   var expectedUrl = provider.get('baseUrl') + '?' + 'response_type=code' +
           '&client_id=' + 'abcdef' +
           '&redirect_uri=' + encodeURIComponent(provider.get('redirectUri')) +
           '&state=STATE' +
-          '&scope=email';
+          '&scope=email' +
+          '&approval_prompt=force';
 
   equal(provider.buildUrl(),
         expectedUrl,


### PR DESCRIPTION
Docs: https://developers.google.com/identity/protocols/OAuth2WebServer#formingtheurl

Fixes https://github.com/Vestorly/torii/issues/139