### PR TITLE
Change usages of deprecated store:main to store:application

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ authorizations. An example application adapter with an `open` hook:
 // Here we will presume the store has been injected onto torii-adapter
 // factories. You would do this with an initializer, e.g.:
 //
-// application.inject('torii-adapter', 'store', 'store:main');
+// application.inject('torii-adapter', 'store', 'store:application');
 //
 export default Ember.Object.extend({
 

--- a/lib/torii/bootstrap/torii.js
+++ b/lib/torii/bootstrap/torii.js
@@ -30,8 +30,8 @@ export default function(container){
   container.injection('torii-provider', 'popup', 'torii-service:popup');
 
   if (window.DS) {
-    container.injection('torii-provider', 'store', 'store:main');
-    container.injection('torii-adapter', 'store', 'store:main');
+    container.injection('torii-provider', 'store', 'store:application');
+    container.injection('torii-adapter', 'store', 'store:application');
   }
 
   return container;


### PR DESCRIPTION
Use `store:application` in favor of `store:main`.

**ember-data#1.0.0-beta.19.1**: `DEPRECATION: You tried to look up 'store:main', but this has been deprecated in favor of 'store:application'.`

**ember-data#1.0.0-beta.19.2**: `Uncaught Error: Attempting to inject an unknown injection: 'store:main'`

Discussion: https://github.com/emberjs/data/pull/3136