### PR TITLE
Walk providers in a instance-initializer (instead of a regular initializer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 [![Torii Build Status](https://circleci.com/gh/Vestorly/torii.png?circle-token=9bdd2f37dbcb0be85f82a6b1ac61b9333b68625b "Torii Build Status")](https://circleci.com/gh/Vestorly/torii) [![Ember Observer Score](http://emberobserver.com/badges/torii.svg)](http://emberobserver.com/addons/torii)
 
+# Compatibilty Matrix
+
+|  Torii    | Ember   | Ember-Data         |
+|-----------|---------|--------------------|
+| v0.3.X    | <= 1.13 | <= 1.0.0.beta19.2  |
+| v0.4.X    | >= 1.12 | >= 1.0.0.beta19.2  |
+
+**tl;dr;** Use the torii 0.3.X if your application is using Ember 1.11 or older.
+
+# What is torii?
+
 Torii is a set of clean abstractions for authentication in [Ember.js](http://emberjs.com/)
 applications. Torii is built with **providers** (authentication against a platform), a
 **session manager** (for maintaining the current user), and **adapters** (to persist

--- a/lib/torii/initializers/initialize-torii.js
+++ b/lib/torii/initializers/initialize-torii.js
@@ -5,16 +5,6 @@ var initializer = {
   name: 'torii',
   initialize: function(container, app){
     bootstrapTorii(container);
-
-    // Walk all configured providers and eagerly instantiate
-    // them. This gives providers with initialization side effects
-    // like facebook-connect a chance to load up assets.
-    for (var key in  configuration.providers) {
-      if (configuration.providers.hasOwnProperty(key)) {
-        container.lookup('torii-provider:'+key);
-      }
-    }
-
     app.inject('route', 'torii', 'torii:main');
   }
 };

--- a/lib/torii/instance-initializers/walk-providers.js
+++ b/lib/torii/instance-initializers/walk-providers.js
@@ -1,0 +1,16 @@
+import configuration from 'torii/configuration';
+
+export default {
+  name: 'torii-walk-providers',
+  initialize: function(appInstance){
+    // Walk all configured providers and eagerly instantiate
+    // them. This gives providers with initialization side effects
+    // like facebook-connect a chance to load up assets.
+    for (var key in  configuration.providers) {
+      if (configuration.providers.hasOwnProperty(key)) {
+        appInstance.container.lookup('torii-provider:'+key);
+      }
+    }
+
+  }
+};

--- a/lib/torii/lib/load-instance-initializer.js
+++ b/lib/torii/lib/load-instance-initializer.js
@@ -1,0 +1,6 @@
+/* global Ember */
+export default function(instanceInitializer){
+  Ember.onLoad('Ember.Application', function(Application){
+    Application.instanceInitializer(instanceInitializer);
+  });
+}

--- a/lib/torii/load-initializers.js
+++ b/lib/torii/load-initializers.js
@@ -1,10 +1,13 @@
 import loadInitializer from 'torii/lib/load-initializer';
+import loadInstanceInitializer from 'torii/lib/load-initializer';
 import initializeTorii from 'torii/initializers/initialize-torii';
 import initializeToriiCallback from 'torii/initializers/initialize-torii-callback';
 import initializeToriiSession from 'torii/initializers/initialize-torii-session';
+import walkProviders from 'torii/instance-initializers/walk-providers';
 
 export default function(){
   loadInitializer(initializeToriiCallback);
   loadInitializer(initializeTorii);
   loadInitializer(initializeToriiSession);
+  loadInstanceInitializer(walkProviders);
 }

--- a/lib/torii/load-initializers.js
+++ b/lib/torii/load-initializers.js
@@ -1,5 +1,5 @@
 import loadInitializer from 'torii/lib/load-initializer';
-import loadInstanceInitializer from 'torii/lib/load-initializer';
+import loadInstanceInitializer from 'torii/lib/load-instance-initializer';
 import initializeTorii from 'torii/initializers/initialize-torii';
 import initializeToriiCallback from 'torii/initializers/initialize-torii-callback';
 import initializeToriiSession from 'torii/initializers/initialize-torii-session';


### PR DESCRIPTION
This fixes #190 

The main reason is that in modern versions of ember-data the store is registered using instance initializers, and since some providers are trying to inject the store, which is not defined at this point, then boom :boom:  with a quite cryptic error message.

This code will only work in versions of ember with instance initializers (1.12+). I'm not sure if bumping the version number to 0.4 and having support only 1.12, 1.13 and 2.0 is enough or we need to do something cleverer for backwards compatibility.

