### PR TITLE
Add a provider for Edmodo Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Torii comes with several providers already included:
   * Facebook Connect (via FB SDK) ([Dev Site](https://developers.facebook.com/) | [Docs](https://developers.facebook.com/docs/))
   * Facebook OAuth2 ([Dev Site](https://developers.facebook.com/) | [Docs](https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow/))
   * Stripe Connect (OAuth2) ([Dev Site](https://stripe.com/docs) | [Docs](https://stripe.com/docs/connect))
+  * Edmodo Connect (OAuth2) ([Dev Site](https://developers.edmodo.com/) | [Docs](https://developers.edmodo.com/edmodo-connect/docs/))
   * **Authoring custom providers is designed to be easy** - You are encouraged to author your own.
 
 ### Supporting OAuth 1.0a

--- a/lib/torii/bootstrap/torii.js
+++ b/lib/torii/bootstrap/torii.js
@@ -9,6 +9,7 @@ import TwitterProvider from 'torii/providers/twitter-oauth1';
 import GithubOauth2Provider from 'torii/providers/github-oauth2';
 import AzureAdOauth2Provider from 'torii/providers/azure-ad-oauth2';
 import StripeConnectProvider from 'torii/providers/stripe-connect';
+import EdmodoConnectProvider from 'torii/providers/edmodo-connect';
 
 import PopupService from 'torii/services/popup';
 
@@ -23,6 +24,7 @@ export default function(container){
   container.register('torii-provider:github-oauth2', GithubOauth2Provider);
   container.register('torii-provider:azure-ad-oauth2', AzureAdOauth2Provider);
   container.register('torii-provider:stripe-connect', StripeConnectProvider);
+  container.register('torii-provider:edmodo-connect', EdmodoConnectProvider);
   container.register('torii-adapter:application', ApplicationAdapter);
 
   container.register('torii-service:popup', PopupService);

--- a/lib/torii/providers/edmodo-connect.js
+++ b/lib/torii/providers/edmodo-connect.js
@@ -1,0 +1,18 @@
+import Oauth2Bearer from 'torii/providers/oauth2-bearer';
+import {configurable} from 'torii/configuration';
+
+/*
+* This class implements authentication against Edmodo
+* with the token flow. For more information see
+* https://developers.edmodo.com/edmodo-connect/docs/#connecting-your-application
+* */
+export default Oauth2Bearer.extend({
+  name: 'edmodo-connect',
+  baseUrl: 'https://api.edmodo.com/oauth/authorize',
+  responseParams: ['access_token'],
+
+  /* Configurable parameters */
+  redirectUri: configurable('redirectUri'),
+  // See https://developers.edmodo.com/edmodo-connect/docs/#connecting-your-application for the full list of scopes
+  scope: configurable('scope', 'basic')
+});

--- a/test/tests/integration/providers/edmodo-connect-test.js
+++ b/test/tests/integration/providers/edmodo-connect-test.js
@@ -1,0 +1,42 @@
+var torii, container;
+
+import toriiContainer from 'test/helpers/torii-container';
+import configuration from 'torii/configuration';
+
+var originalConfiguration = configuration.providers['edmodo-connect'];
+
+var opened, mockPopup;
+
+module('Edmodo Connect - Integration', {
+  setup: function(){
+    mockPopup = {
+      open: function(){
+        opened = true;
+        return Ember.RSVP.resolve({ access_token: 'test' });
+      }
+    };
+    container = toriiContainer();
+    container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
+    container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
+
+    torii = container.lookup("torii:main");
+    configuration.providers['edmodo-connect'] = {
+      apiKey: 'dummy',
+      redirectUri: 'some url'
+    };
+  },
+  teardown: function(){
+    opened = false;
+    configuration.providers['edmodo-connect'] = originalConfiguration;
+    Ember.run(container, 'destroy');
+  }
+});
+
+test("Opens a popup to Edmodo", function(){
+  expect(1);
+  Ember.run(function(){
+    torii.open('edmodo-connect').finally(function(){
+      ok(opened, "Popup service is opened");
+    });
+  });
+});

--- a/test/tests/unit/providers/edmodo-connect-test.js
+++ b/test/tests/unit/providers/edmodo-connect-test.js
@@ -1,0 +1,52 @@
+var provider;
+
+import configuration from 'torii/configuration';
+
+import EdmodoConnectProvider from 'torii/providers/edmodo-connect';
+
+module('Unit - EdmodoConnectProvider', {
+  setup: function(){
+    configuration.providers['edmodo-connect'] = {};
+    provider = new EdmodoConnectProvider();
+  },
+  teardown: function(){
+    Ember.run(provider, 'destroy');
+    configuration.providers['edmodo-connect'] = {};
+  }
+});
+
+test("Provider requires an apiKey", function(){
+  configuration.providers['edmodo-connect'] = {};
+  throws(function(){
+    provider.buildUrl();
+  }, /Expected configuration value providers.edmodo-connect.apiKey to be defined!/);
+});
+
+test("Provider requires a redirectUri", function(){
+  configuration.providers['edmodo-connect'] = {
+    apiKey: 'abcdef'
+  };
+  throws(function(){
+    provider.buildUrl();
+  }, /Expected configuration value providers.edmodo-connect.redirectUri to be defined!/);
+});
+
+test("baseUrl is 'https://api.edmodo.com/oauth/authorize'", function() {
+  equal(provider.get('baseUrl'), 'https://api.edmodo.com/oauth/authorize');
+});
+
+test("Provider generates a URL with required config", function(){
+  configuration.providers['edmodo-connect'] = {
+    apiKey: 'abcdef',
+    redirectUri: 'http://localhost:4200/edmodo/callback'
+  };
+
+  var expectedUrl = provider.get('baseUrl') + '?' + 'response_type=token' +
+          '&client_id=' + 'abcdef' +
+          '&redirect_uri=' + encodeURIComponent('http://localhost:4200/edmodo/callback') +
+          '&scope=basic';
+
+  equal(provider.buildUrl(),
+        expectedUrl,
+        'generates the correct URL');
+});


### PR DESCRIPTION
This PR adds a provider for Edmodo Connect (see https://developers.edmodo.com/edmodo-connect/). It's very simple as it just re-uses the logic from the `OAuth2Bearer` provider.