### PR TITLE
Changed inter-window communication to use localStorage events

### DIFF
--- a/lib/torii/initializers/initialize-torii-callback.js
+++ b/lib/torii/initializers/initialize-torii-callback.js
@@ -5,7 +5,7 @@ export default {
   before: 'torii',
   initialize: function(container, app){
     app.deferReadiness();
-    RedirectHandler.handle(window.location.toString()).catch(function(){
+    RedirectHandler.handle(window).catch(function(){
       app.advanceReadiness();
     });
   }

--- a/lib/torii/lib/popup-id-serializer.js
+++ b/lib/torii/lib/popup-id-serializer.js
@@ -1,0 +1,17 @@
+var PopupIdSerializer = {
+  serialize: function(popupId){
+    return "torii-popup:" + popupId;
+  },
+
+  deserialize: function(serializedPopupId){
+    if (!serializedPopupId){
+      return null;
+    }
+
+    var match = serializedPopupId.match(/^(torii-popup:)(.*)/);
+    return match ? match[2] : null;
+  },
+};
+
+
+export default PopupIdSerializer;

--- a/lib/torii/lib/uuid-generator.js
+++ b/lib/torii/lib/uuid-generator.js
@@ -1,0 +1,15 @@
+var UUIDGenerator = {
+  generate: function() {
+    var d = new Date().getTime();
+    var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c==='x' ? r : (r&0x3|0x8)).toString(16);
+    });
+    return uuid;
+  },
+
+
+};
+
+export default UUIDGenerator;

--- a/lib/torii/redirect-handler.js
+++ b/lib/torii/redirect-handler.js
@@ -6,22 +6,30 @@
  * and should postMessage this data to window.opener
  */
 
-import {postMessageFixed, readToriiMessage} from "./services/popup";
+import PopupIdSerializer from "./lib/popup-id-serializer";
+
 
 var RedirectHandler = Ember.Object.extend({
 
-  init: function(url){
-    this.url = url;
+  init: function(windowObject){
+    this.windowObject = windowObject;
   },
 
   run: function(){
-    var url = this.url;
+    var windowObject = this.windowObject;
+
     return new Ember.RSVP.Promise(function(resolve, reject){
-      if (window.opener && window.opener.name === 'torii-opener') {
-        postMessageFixed(window.opener, url);
-        window.close();
-      } else {
-        reject('No window.opener');
+      var popupId = PopupIdSerializer.deserialize(windowObject.name);
+
+      if (popupId){
+        var key = PopupIdSerializer.serialize(popupId);
+        var url = windowObject.location.toString();
+
+        windowObject.localStorage.setItem(key, url);
+
+        windowObject.close();
+      } else{
+        reject('Not a torii popup');
       }
     });
   }
@@ -30,8 +38,8 @@ var RedirectHandler = Ember.Object.extend({
 
 RedirectHandler.reopenClass({
   // untested
-  handle: function(url){
-    var handler = new RedirectHandler(url);
+  handle: function(windowObject){
+    var handler = new RedirectHandler(windowObject);
     return handler.run();
   }
 });

--- a/lib/torii/services/popup.js
+++ b/lib/torii/services/popup.js
@@ -47,6 +47,7 @@ function parseMessage(url, keys){
 var Popup = Ember.Object.extend(Ember.Evented, {
 
   init: function(options){
+    this._super.apply(this, arguments);
     options = options || {};
     this.popupIdGenerator = options.popupIdGenerator || UUIDGenerator;
   },
@@ -92,7 +93,7 @@ var Popup = Ember.Object.extend(Ember.Evented, {
         }, 100);
       });
 
-      Ember.$(window).on('storage', function(event){
+      Ember.$(window).on('storage.torii', function(event){
         var storageEvent = event.originalEvent;
 
         var popupIdFromEvent = PopupIdSerializer.deserialize(storageEvent.key);
@@ -111,7 +112,7 @@ var Popup = Ember.Object.extend(Ember.Evented, {
       // didClose will reject this same promise, but it has already resolved.
       service.close();
       service.clearTimeout();
-      Ember.$(window).off('storage');
+      Ember.$(window).off('storage.torii');
     });
   },
 

--- a/lib/torii/services/popup.js
+++ b/lib/torii/services/popup.js
@@ -1,27 +1,8 @@
 import ParseQueryString from 'torii/lib/parse-query-string';
+import UUIDGenerator from 'torii/lib/uuid-generator';
+import PopupIdSerializer from 'torii/lib/popup-id-serializer';
 
 var on = Ember.on;
-
-var postMessageFixed;
-var postMessageDomain = window.location.protocol+'//'+window.location.host;
-var postMessagePrefix = "__torii_message:";
-// in IE11 window.attachEvent was removed.
-if (window.attachEvent) {
-  postMessageFixed = function postMessageFixed(win, data) {
-    win.postMessageWithFix(postMessagePrefix+data, postMessageDomain);
-  };
-  window.postMessageWithFix = function postMessageWithFix(data, domain) {
-    setTimeout(function(){
-      window.postMessage(data, domain);
-    }, 0);
-  };
-} else {
-  postMessageFixed = function postMessageFixed(win, data) {
-    win.postMessage(postMessagePrefix+data, postMessageDomain);
-  };
-}
-
-export {postMessageFixed};
 
 function stringifyOptions(options){
   var optionsStrings = [];
@@ -57,14 +38,6 @@ function prepareOptions(options){
   }, options);
 }
 
-function readToriiMessage(message){
-  if (message && typeof message === 'string' && message.indexOf(postMessagePrefix) === 0) {
-    return message.slice(postMessagePrefix.length);
-  }
-}
-
-export {readToriiMessage};
-
 function parseMessage(url, keys){
   var parser = new ParseQueryString(url, keys),
       data = parser.parse();
@@ -72,6 +45,11 @@ function parseMessage(url, keys){
 }
 
 var Popup = Ember.Object.extend(Ember.Evented, {
+
+  init: function(options){
+    options = options || {};
+    this.popupIdGenerator = options.popupIdGenerator || UUIDGenerator;
+  },
 
   // Open a popup window. Returns a promise that resolves or rejects
   // accoring to if the popup is redirected with arguments in the URL.
@@ -86,17 +64,17 @@ var Popup = Ember.Object.extend(Ember.Evented, {
     var service   = this,
         lastPopup = this.popup;
 
-    var oldName = window.name;
-    // Is checked by the popup to see if it was opened by Torii
-    window.name = 'torii-opener';
 
     return new Ember.RSVP.Promise(function(resolve, reject){
       if (lastPopup) {
         service.close();
       }
 
+      var popupId = service.popupIdGenerator.generate();
+
       var optionsString = stringifyOptions(prepareOptions(options || {}));
-      service.popup = window.open(url, '_blank', optionsString);
+      var windowName = PopupIdSerializer.serialize(popupId);
+      service.popup = window.open(url, windowName, optionsString);
 
       if (service.popup && !service.popup.closed) {
         service.popup.focus();
@@ -114,11 +92,13 @@ var Popup = Ember.Object.extend(Ember.Evented, {
         }, 100);
       });
 
-      Ember.$(window).on('message.torii', function(event){
-        var message = event.originalEvent.data;
-        var toriiMessage = readToriiMessage(message);
-        if (toriiMessage) {
-          var data = parseMessage(toriiMessage, keys);
+      Ember.$(window).on('storage', function(event){
+        var storageEvent = event.originalEvent;
+
+        var popupIdFromEvent = PopupIdSerializer.deserialize(storageEvent.key);
+        if (popupId === popupIdFromEvent){
+          var data = parseMessage(storageEvent.newValue, keys);
+          localStorage.removeItem(storageEvent.key);
           Ember.run(function() {
             resolve(data);
           });
@@ -131,8 +111,7 @@ var Popup = Ember.Object.extend(Ember.Evented, {
       // didClose will reject this same promise, but it has already resolved.
       service.close();
       service.clearTimeout();
-      window.name = oldName;
-      Ember.$(window).off('message.torii');
+      Ember.$(window).off('storage');
     });
   },
 
@@ -168,7 +147,6 @@ var Popup = Ember.Object.extend(Ember.Evented, {
   stopPolling: on('didClose', function(){
     Ember.run.cancel(this.polling);
   }),
-
 
 });
 

--- a/test/tests/unit/lib/popup-id-serializer-test.js
+++ b/test/tests/unit/lib/popup-id-serializer-test.js
@@ -1,0 +1,25 @@
+import PopupIdSerializer from 'torii/lib/popup-id-serializer';
+
+module('PopupIdSerializer - Unit');
+
+test('.serialize prepends a prefix before the popup id', function(){
+  var popupId = "abc12345"
+
+  equal("torii-popup:" + popupId, PopupIdSerializer.serialize(popupId));
+});
+
+test('.deserialize extracts the popup id from the serialized string', function(){
+  var serializedPopupId = "torii-popup:gfedc123";
+
+  equal("gfedc123", PopupIdSerializer.deserialize(serializedPopupId));
+});
+
+test('.deserialize returns null if not a properly serialized torii popup', function(){
+  var serializedPopupId = "";
+
+  equal(null, PopupIdSerializer.deserialize(serializedPopupId));
+});
+
+test('.serialize returns null if passed undefined', function(){
+  equal(null, PopupIdSerializer.deserialize(undefined));
+});

--- a/test/tests/unit/lib/uuid-generator-test.js
+++ b/test/tests/unit/lib/uuid-generator-test.js
@@ -1,0 +1,14 @@
+import UUIDGenerator from 'torii/lib/uuid-generator';
+
+module('UUIDGenerator - Unit');
+
+test('exists', function(){
+  ok(UUIDGenerator);
+});
+
+test('.generate returns a new uuid each time', function(){
+  var first = UUIDGenerator.generate();
+  var second = UUIDGenerator.generate();
+
+  notEqual(first, second);
+});


### PR DESCRIPTION
This should fix #193. Any feedback and suggestions are welcome.

window.opener was being cleared after visiting a different host in Chrome 43 and Firefox 38. This change uses local storage events + unique popup ids to communicate between windows. Here’s an overview of how it works.

1. When popup.open is called, it generates a new torii popup id (uuid) and sets it as the popup window's name.
2. When RedirectHandler#handle is called in a window that has a valid torii popup id as its name, it stores the popup id and the current url of the popup window in local storage
3. When the new key/value is set in local storage, the popup service is notified via the browser's storage event. If event.key contains the popup id we’re looking for, it extracts the auth code from the url, resolves the promise, and removes the key from local storage.

Other notes

* We don't need to worry about opening popup with a name of `_blank` anymore. According to the commit log, the window was being named "_blank" because of an issue where window.opener wasn't being set in Chrome for iOS. Since we aren't using window.opener anymore, we should be able to set the window name to the popup id.


I have tested these changes in my application in the following browsers

* Chrome 43 on OSX 10.10
* Firefox 48 on OSX 10.10
* Safari 8.0.6 on OSX 10.10
* IE 11.0.9600 on Windows 8.1

Please let me know what you think, and if there are changes that need to be made.