### PR TITLE
Remove use of window.name as a channel for localStorage messages

### DIFF
--- a/lib/torii/redirect-handler.js
+++ b/lib/torii/redirect-handler.js
@@ -7,7 +7,7 @@
  */
 
 import PopupIdSerializer from "./lib/popup-id-serializer";
-
+import { CURRENT_REQUEST_KEY } from "./services/popup";
 
 var RedirectHandler = Ember.Object.extend({
 
@@ -19,13 +19,11 @@ var RedirectHandler = Ember.Object.extend({
     var windowObject = this.windowObject;
 
     return new Ember.RSVP.Promise(function(resolve, reject){
-      var popupId = PopupIdSerializer.deserialize(windowObject.name);
-
-      if (popupId){
-        var key = PopupIdSerializer.serialize(popupId);
+      var pendingRequestKey = windowObject.localStorage.getItem(CURRENT_REQUEST_KEY);
+      windowObject.localStorage.removeItem(CURRENT_REQUEST_KEY);
+      if (pendingRequestKey) {
         var url = windowObject.location.toString();
-
-        windowObject.localStorage.setItem(key, url);
+        windowObject.localStorage.setItem(pendingRequestKey, url);
 
         windowObject.close();
       } else{

--- a/lib/torii/services/popup.js
+++ b/lib/torii/services/popup.js
@@ -2,6 +2,8 @@ import ParseQueryString from 'torii/lib/parse-query-string';
 import UUIDGenerator from 'torii/lib/uuid-generator';
 import PopupIdSerializer from 'torii/lib/popup-id-serializer';
 
+export var CURRENT_REQUEST_KEY = '__torii_request';
+
 var on = Ember.on;
 
 function stringifyOptions(options){
@@ -74,8 +76,9 @@ var Popup = Ember.Object.extend(Ember.Evented, {
       var popupId = service.popupIdGenerator.generate();
 
       var optionsString = stringifyOptions(prepareOptions(options || {}));
-      var windowName = PopupIdSerializer.serialize(popupId);
-      service.popup = window.open(url, windowName, optionsString);
+      var pendingRequestKey = PopupIdSerializer.serialize(popupId);
+      localStorage.setItem(CURRENT_REQUEST_KEY, pendingRequestKey);
+      service.popup = window.open(url, pendingRequestKey, optionsString);
 
       if (service.popup && !service.popup.closed) {
         service.popup.focus();
@@ -86,6 +89,11 @@ var Popup = Ember.Object.extend(Ember.Evented, {
       }
 
       service.one('didClose', function(){
+        var pendingRequestKey = localStorage.getItem(CURRENT_REQUEST_KEY);
+        if (pendingRequestKey) {
+          localStorage.removeItem(pendingRequestKey);
+          localStorage.removeItem(CURRENT_REQUEST_KEY);
+        }
         // If we don't receive a message before the timeout, we fail. Normally,
         // the message will be received and the window will close immediately.
         service.timeout = Ember.run.later(service, function() {


### PR DESCRIPTION
window.name was used to decide what item key would be used for a popup's message to the parent. This is nor reliable, as some browsers leak the fact that Facebook (and other popups) may set a window name that destroys the one set by Torii.

Instead, this patch uses a global key set by torii, identifying a "current channel" that expects to receive the message. This is not perfect, as a window opening a torii request after an different window
may receive the completed auth from the window of the first request. However in a practical sense it means the last window starting auth will receive the messages from auth popups, and old windows that may have started auth will receive none.

See https://github.com/Vestorly/torii/pull/195#issuecomment-119669300