### PR TITLE
facebook-connect - Add support for return scopes

### DIFF
--- a/lib/torii/providers/facebook-connect.js
+++ b/lib/torii/providers/facebook-connect.js
@@ -34,7 +34,7 @@ function fbLoad(settings){
   return fbPromise;
 }
 
-function fbLogin(scope){
+function fbLogin(scope, returnScopes){
   return new Ember.RSVP.Promise(function(resolve, reject){
     FB.login(function(response){
       if (response.authResponse) {
@@ -42,16 +42,20 @@ function fbLogin(scope){
       } else {
         Ember.run(null, reject, response.status);
       }
-    }, { scope: scope });
+    }, { scope: scope, return_scopes: returnScopes });
   });
 }
 
 function fbNormalize(response){
-  return {
+  var normalized = {
     userId: response.userID,
     accessToken: response.accessToken,
     expiresIn: response.expiresIn
   };
+  if (response.grantedScopes) {
+    normalized.grantedScopes = response.grantedScopes;
+  }
+  return normalized;
 }
 
 var Facebook = Provider.extend({
@@ -59,6 +63,7 @@ var Facebook = Provider.extend({
   // Facebook connect SDK settings:
   name:  'facebook-connect',
   scope: configurable('scope', 'email'),
+  returnScopes: configurable('returnScopes', false),
   appId: configurable('appId'),
   version: configurable('version', 'v2.2'),
   xfbml: configurable('xfbml', false),
@@ -69,10 +74,11 @@ var Facebook = Provider.extend({
   //
   open: function(){
     var scope = this.get('scope');
+    var returnScopes = this.get('returnScopes');
 
     return fbLoad( this.settings() )
       .then(function(){
-        return fbLogin(scope);
+        return fbLogin(scope, returnScopes);
       })
       .then(fbNormalize);
   },

--- a/test/helpers/build-fb-mock.js
+++ b/test/helpers/build-fb-mock.js
@@ -1,9 +1,11 @@
 export default function(){
   return {
     init: function(){},
-    login: function(callback){
+    login: function(callback, options){
+      var authResponse = { expiresIn: 1234 };
+      if (options.return_scopes == true) authResponse.grantedScopes = 'email';
       callback({
-        authResponse: 1234,
+        authResponse: authResponse,
         status: 567
       });
     }

--- a/test/tests/integration/providers/facebook-connect-test.js
+++ b/test/tests/integration/providers/facebook-connect-test.js
@@ -35,3 +35,15 @@ test("Opens facebook connect session", function(){
     });
   });
 });
+
+test("Returns the scopes granted when configured", function(){
+  $.getScript = function(){
+    window.fbAsyncInit();
+  };
+  configuration.providers['facebook-connect'].returnScopes = true;
+  Ember.run(function(){
+    torii.open('facebook-connect').then(function(data){
+      equal('email', data.grantedScopes);
+    });
+  });
+});


### PR DESCRIPTION
Adds a configuration option to facebook-connect provider to return the granted scopes back with the response data. This is useful when trying to determine if a user omitted any required scopes during the sign in process.

Defaults to off and is only added to the normalized response when configured.