### PR TITLE
facebook-connect - Add support for auth_type

### DIFF
--- a/lib/torii/providers/facebook-connect.js
+++ b/lib/torii/providers/facebook-connect.js
@@ -34,7 +34,7 @@ function fbLoad(settings){
   return fbPromise;
 }
 
-function fbLogin(scope, returnScopes){
+function fbLogin(scope, returnScopes, authType){
   return new Ember.RSVP.Promise(function(resolve, reject){
     FB.login(function(response){
       if (response.authResponse) {
@@ -42,7 +42,7 @@ function fbLogin(scope, returnScopes){
       } else {
         Ember.run(null, reject, response.status);
       }
-    }, { scope: scope, return_scopes: returnScopes });
+    }, { scope: scope, return_scopes: returnScopes, auth_type: authType });
   });
 }
 
@@ -72,13 +72,15 @@ var Facebook = Provider.extend({
 
   // API:
   //
-  open: function(){
+  open: function(options){
+    if (options === undefined) options = {};
     var scope = this.get('scope');
+    var authType = options.authType;
     var returnScopes = this.get('returnScopes');
 
     return fbLoad( this.settings() )
       .then(function(){
-        return fbLogin(scope, returnScopes);
+        return fbLogin(scope, returnScopes, authType);
       })
       .then(fbNormalize);
   },

--- a/test/helpers/build-fb-mock.js
+++ b/test/helpers/build-fb-mock.js
@@ -4,6 +4,7 @@ export default function(){
     login: function(callback, options){
       var authResponse = { expiresIn: 1234 };
       if (options.return_scopes == true) authResponse.grantedScopes = 'email';
+      if (options.auth_type === 'rerequest') authResponse.expiresIn = 5678;
       callback({
         authResponse: authResponse,
         status: 567

--- a/test/tests/integration/providers/facebook-connect-test.js
+++ b/test/tests/integration/providers/facebook-connect-test.js
@@ -47,3 +47,14 @@ test("Returns the scopes granted when configured", function(){
     });
   });
 });
+
+test("Supports custom auth_type on login", function(){
+  $.getScript = function(){
+    window.fbAsyncInit();
+  };
+  Ember.run(function(){
+    torii.open('facebook-connect', {authType: 'rerequest'}).then(function(data){
+      equal(5678, data.expiresIn, 'expriesIn extended when rerequest found');
+    });
+  });
+});


### PR DESCRIPTION
Adds the ability to set the `auth_type` when connecting to Facebook. Currently
Facebook only supports `rerequest` which allows for requesting declined 
permissions.

This is not suitable for global configuration because you may not always
want to rerequest permissions but do it based on other conditions. As
such its passed through to the open function in options. It defaults
to not being set (aka the standard facebook-connect auth_type).