### PR TITLE
authenticatedRoute Router DSL

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,18 @@
   "version": "0.5.1",
   "description": "A set of clean abstractions for authentication in Ember.js",
   "authors": [
-    {"name": "Matt Beale", "email": "matt.beale@madhatted.com"},
-    {"name": "Cory Forsyth", "email": "cory.forsyth@gmail.com"},
-    {"name": "Vestorly", "email": "hello@vestorly.com"}
+    {
+      "name": "Matt Beale",
+      "email": "matt.beale@madhatted.com"
+    },
+    {
+      "name": "Cory Forsyth",
+      "email": "cory.forsyth@gmail.com"
+    },
+    {
+      "name": "Vestorly",
+      "email": "hello@vestorly.com"
+    }
   ],
   "homepage": "http://vestorly.github.io/torii/",
   "keywords": [
@@ -40,14 +49,13 @@
     "url": "git://github.com/Vestorly/torii.git"
   },
   "dependencies": {
-    "ember": "^1.3.0"
+    "ember": ">= 1.8.1"
   },
   "devDependencies": {
-    "handlebars": "^1.3.0",
     "jquery": ">= 1.9.1",
     "qunit": "^1.12.0",
     "ember-qunit": "~0.1.5",
-    "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#master",
+    "ember-resolver": "ember-cli/ember-resolver#v0.1.21",
     "loader": "git://github.com/stefanpenner/loader.js#1.0.0"
   }
 }

--- a/ember-addon/index.js
+++ b/ember-addon/index.js
@@ -10,11 +10,19 @@ module.exports = {
 
   treeForApp: function treeForApp(tree) {
     var Funnel = require('broccoli-funnel');
+    var mergeTrees = require('broccoli-merge-trees');
 
-    return new Funnel(tree, {
+    var initializers = new Funnel(tree, {
       srcDir: 'initializers',
       destDir: 'initializers'
     });
+
+    var instanceInitializers = new Funnel(tree, {
+      srcDir: 'instance-initializers',
+      destDir: 'instance-initializers'
+    })
+
+    return mergeTrees([initializers, instanceInitializers]);
   },
 
   treeForAddon: function treeForAddon() {

--- a/lib/torii/bootstrap/routing.js
+++ b/lib/torii/bootstrap/routing.js
@@ -1,0 +1,17 @@
+import ApplicationRouteMixin from 'torii/routing/application-route-mixin';
+import AuthenticatedRouteMixin from 'torii/routing/authenticated-route-mixin';
+
+export default function(container, authenticatedRoutes){
+
+  var ApplicationRoute = container.lookup('route:application');
+  ApplicationRoute.reopen(ApplicationRouteMixin);
+
+  for (var i = 0; i < authenticatedRoutes.length; i++) {
+    var routeName = authenticatedRoutes[i];
+    var factoryName = 'route:' + routeName;
+    var routeClass = container.lookup(factoryName);
+    routeClass.reopen(AuthenticatedRouteMixin);
+  }
+
+  return container;
+}

--- a/lib/torii/instance-initializers/setup-routes.js
+++ b/lib/torii/instance-initializers/setup-routes.js
@@ -1,0 +1,21 @@
+import configuration from 'torii/configuration';
+import bootstrapRouting from 'torii/bootstrap/routing';
+import "torii/router-dsl-ext";
+
+export default {
+  name: 'torii-setup-routes',
+  initialize: function(appInstance){
+    if (configuration.sessionServiceName) {
+      var router = appInstance.get('router');
+      var setupRoutes = function(){
+        var authenticatedRoutes = router.router.authenticatedRoutes;
+        var hasAuthenticatedRoutes = !Ember.isEmpty(authenticatedRoutes);
+        if (hasAuthenticatedRoutes) {
+          bootstrapRouting(appInstance.container, authenticatedRoutes);
+        }
+        router.off('willTransition', setupRoutes);
+      };
+      router.on('willTransition', setupRoutes);
+    }
+  }
+};

--- a/lib/torii/load-initializers.js
+++ b/lib/torii/load-initializers.js
@@ -3,6 +3,7 @@ import loadInstanceInitializer from 'torii/lib/load-instance-initializer';
 import initializeTorii from 'torii/initializers/initialize-torii';
 import initializeToriiCallback from 'torii/initializers/initialize-torii-callback';
 import initializeToriiSession from 'torii/initializers/initialize-torii-session';
+import setupRoutes from 'torii/instance-initializers/setup-routes';
 import walkProviders from 'torii/instance-initializers/walk-providers';
 
 export default function(){
@@ -10,4 +11,5 @@ export default function(){
   loadInitializer(initializeTorii);
   loadInitializer(initializeToriiSession);
   loadInstanceInitializer(walkProviders);
+  loadInstanceInitializer(setupRoutes);
 }

--- a/lib/torii/router-dsl-ext.js
+++ b/lib/torii/router-dsl-ext.js
@@ -1,0 +1,17 @@
+var Router = Ember.Router;
+var proto = Ember.RouterDSL.prototype;
+
+var currentMap = null;
+
+proto.authenticatedRoute = function() {
+  this.route.apply(this, arguments);
+  currentMap.push(arguments[0]);
+};
+
+Router.reopen({
+  _initRouterJs: function() {
+    currentMap = [];
+    this._super();
+    this.router.authenticatedRoutes = currentMap;
+  }
+});

--- a/lib/torii/routing/application-route-mixin.js
+++ b/lib/torii/routing/application-route-mixin.js
@@ -1,0 +1,19 @@
+export default Ember.Mixin.create({
+  beforeModel: function (transition) {
+    var route = this;
+    var superBefore = this._super.apply(this, arguments);
+    if (superBefore && superBefore.then) {
+      return superBefore.then(function() {
+        return route.checkLogin(transition);
+      });
+    } else {
+      return route.checkLogin(transition);
+    }
+  },
+  checkLogin: function () {
+    return this.session.fetch()
+      .catch(function(){
+        // no-op, cause no session is ok
+      });
+  }
+});

--- a/lib/torii/routing/authenticated-route-mixin.js
+++ b/lib/torii/routing/authenticated-route-mixin.js
@@ -1,0 +1,32 @@
+export default Ember.Mixin.create({
+  beforeModel: function (transition) {
+    var route = this;
+    var superBefore = this._super.apply(this, arguments);
+    if (superBefore && superBefore.then) {
+      return superBefore.then(function() {
+        return route.authenticate(transition);
+      });
+    } else {
+      return route.authenticate(transition);
+    }
+  },
+  authenticate: function (transition) {
+    var route = this;
+    var isAuthenticated = this.get('session.isAuthenticated');
+    if (isAuthenticated === undefined) {
+      this.session.attemptedTransition = transition;
+      return this.session.fetch()
+        .catch(function() {
+          return route.accessDenied(transition);
+        });
+    } else if (isAuthenticated) {
+      // no-op; cause the user is already authenticated
+      return Ember.RSVP.resolve();
+    } else {
+      return this.accessDenied(transition);
+    }
+  },
+  accessDenied: function (transition) {
+    transition.send('accessDenied');
+  }
+});

--- a/lib/torii/services/torii-session.js
+++ b/lib/torii/services/torii-session.js
@@ -94,5 +94,4 @@ export default Ember.Service.extend(Ember._ProxyMixin, {
       return Ember.RSVP.reject(error);
     });
   }
-
 });

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "license": "MIT",
   "dependencies": {
     "broccoli-funnel": "^0.2.2",
-    "broccoli-string-replace": "^0.0.2"
+    "broccoli-string-replace": "^0.0.2",
+    "broccoli-merge-trees": "^0.2.2"
   }
 }

--- a/test/helpers/initialize-torii.js
+++ b/test/helpers/initialize-torii.js
@@ -1,9 +1,11 @@
 import initializeTorii from 'torii/initializers/initialize-torii';
 import initializeToriiCallback from 'torii/initializers/initialize-torii-callback';
 import initializeToriiSession from 'torii/initializers/initialize-torii-session';
+import instanceInitializeToriiRoutes from 'torii/instance-initializers/setup-routes';
 
 export default function(Application){
   Application.initializer( initializeToriiCallback );
   Application.initializer( initializeTorii );
   Application.initializer( initializeToriiSession );
+  Application.instanceInitializer( instanceInitializeToriiRoutes );
 }

--- a/test/helpers/start-app.js
+++ b/test/helpers/start-app.js
@@ -5,6 +5,7 @@ function startApp(attrs) {
   if (!attrs) { attrs = {}; }
 
   var loadInitializers = attrs.loadInitializers;
+  var Router = attrs.Router;
 
   var attributes = Ember.merge({
     // useful Test defaults
@@ -14,9 +15,13 @@ function startApp(attrs) {
   }, attrs); // but you can override;
 
   var Application = Ember.Application.extend();
-  Application.Router = Ember.Router.extend({
+
+  Router = Router || Ember.Router.extend();
+  Router.reopen({
     location: 'none'
   });
+
+  Application.Router = Router;
 
   if (loadInitializers) {
     initializeTorii(Application);

--- a/test/tests/acceptance/routing-test.js
+++ b/test/tests/acceptance/routing-test.js
@@ -1,0 +1,120 @@
+import startApp from 'test/helpers/start-app';
+import configuration from 'torii/configuration';
+import AuthenticatedRouteMixin from 'torii/routing/authenticated-route-mixin';
+
+var app, originalSessionServiceName;
+
+module('Routing - Acceptance', {
+  setup: function(){
+    originalSessionServiceName = configuration.sessionServiceName;
+    delete configuration.sessionServiceName;
+  },
+
+  teardown: function(){
+    Ember.run(app, 'destroy');
+    configuration.sessionServiceName = originalSessionServiceName;
+  }
+});
+
+test('ApplicationRoute#checkLogin is not called when no authenticated routes are present', function(assert){
+  assert.expect(2);
+  configuration.sessionServiceName = 'session';
+
+  var routesConfigured = false;
+  var checkLoginCalled = false;
+
+  return bootApp({
+    map: function() {
+      routesConfigured = true;
+    },
+    container: function(container) {
+      container.register('route:application', Ember.Route.extend());
+    }
+  }).then(function(){
+    var applicationRoute = app.__container__.lookup('route:application');
+    applicationRoute.reopen({
+      checkLogin: function() {
+        checkLoginCalled = true;
+      }
+    })
+    applicationRoute.beforeModel();
+    assert.ok(routesConfigured, 'Router map was called');
+    assert.ok(!checkLoginCalled, 'checkLogin was not called');
+  });
+})
+
+test('ApplicationRoute#checkLogin is called when an authenticated route is present', function(assert){
+  assert.expect(2);
+  configuration.sessionServiceName = 'session';
+
+  var routesConfigured = false;
+  var checkLoginCalled = false;
+
+  return bootApp({
+    map: function() {
+      routesConfigured = true;
+      this.authenticatedRoute('account');
+    },
+    container: function(container) {
+      container.register('route:application', Ember.Route.extend());
+      container.register('route:account', Ember.Route.extend());
+    }
+  }).then(function(){
+    var applicationRoute = app.__container__.lookup('route:application');
+    applicationRoute.reopen({
+      checkLogin: function() {
+        checkLoginCalled = true;
+      }
+    });
+    applicationRoute.beforeModel();
+    assert.ok(routesConfigured, 'Router map was called');
+    assert.ok(checkLoginCalled, 'checkLogin was called');
+  });
+});
+
+test('authenticated routes get authenticate method', function(assert){
+  assert.expect(2);
+  configuration.sessionServiceName = 'session';
+
+  var checkLoginCalled = false;
+
+  return bootApp({
+    map: function() {
+      this.route('home');
+      this.authenticatedRoute('account');
+    },
+    container: function(container) {
+      container.register('route:application', Ember.Route.extend());
+      container.register('route:account', Ember.Route.extend());
+      container.register('route:home', Ember.Route.extend());
+    }
+  }).then(function(){
+    var authenticatedRoute = app.__container__.lookup('route:account');
+    var unauthenticatedRoute = app.__container__.lookup('route:home');
+
+    assert.ok(authenticatedRoute.authenticate, "authenticate function is present");
+    assert.ok(!unauthenticatedRoute.authenticate, "authenticate function is not present");
+  });
+});
+
+function bootApp(attrs) {
+  var map = attrs.map || function(){};
+  var containerSetup = attrs.container || function() {};
+
+  var Router = Ember.Router.extend();
+
+  Router.map(map);
+
+  app = startApp({
+    loadInitializers: true,
+    Router: Router
+  });
+
+  containerSetup(app.__container__);
+
+  Ember.run(function(){
+    app.advanceReadiness();
+  });
+
+  return app.boot();
+}

--- a/test/tests/unit/routing/application-route-mixin-test.js
+++ b/test/tests/unit/routing/application-route-mixin-test.js
@@ -1,0 +1,71 @@
+import ApplicationRouteMixin from 'torii/routing/application-route-mixin';
+
+module('Application Route Mixin - Unit');
+
+test("beforeModel calls checkLogin after _super#beforeModel", function(assert){
+  var route;
+  var callOrder = [];
+  route = Ember.Route
+    .extend({
+      beforeModel: function() {
+        callOrder.push('super');
+      }
+    })
+    .extend(ApplicationRouteMixin, {
+      checkLogin: function() {
+        callOrder.push('mixin');
+      }
+    }).create();
+
+  route.beforeModel();
+
+  assert.deepEqual(callOrder, ['super', 'mixin'],
+    'super#beforeModel is called mixin#beforeModel');
+});
+
+test("beforeModel calls checkLogin after promise from _super#beforeModel is resolved", function(assert){
+  var route;
+  var callOrder = [];
+  route = Ember.Route
+    .extend({
+      beforeModel: function() {
+        return new Ember.RSVP.Promise(function(resolve){
+          Ember.run.later(function(){
+            callOrder.push('super');
+            resolve();
+          }, 20);
+        })
+      }
+    })
+    .extend(ApplicationRouteMixin, {
+      checkLogin: function() {
+        callOrder.push('mixin');
+      }
+    }).create();
+
+  return route.beforeModel()
+    .then(function(){
+      assert.deepEqual(callOrder, ['super', 'mixin'],
+        'super#beforeModel is called before mixin#beforeModel');
+    });
+});
+
+test('checkLogic fails silently when no session is available', function(assert){
+  assert.expect(2);
+
+  var fetchCalled = false;
+  var route = Ember.Route.extend(ApplicationRouteMixin, {
+    session: {
+      fetch: function() {
+        fetchCalled = true;
+        return Ember.RSVP.reject('no session is available');
+      }
+    }
+  }).create();
+
+  return route.checkLogin()
+    .then(function(){
+      assert.ok(fetchCalled, 'fetch default provider was called');
+      assert.ok('successful callback in spite of rejection');
+    })
+})

--- a/test/tests/unit/routing/authenticated-route-mixin-test.js
+++ b/test/tests/unit/routing/authenticated-route-mixin-test.js
@@ -1,0 +1,134 @@
+import AuthenticatedRouteMixin from 'torii/routing/authenticated-route-mixin';
+
+module('Authenticated Route Mixin - Unit');
+
+test("beforeModel calls authenicate after _super#beforeModel", function(assert){
+  var route;
+  var callOrder = [];
+  route = Ember.Route
+    .extend({
+      beforeModel: function() {
+        callOrder.push('super');
+      }
+    })
+    .extend(AuthenticatedRouteMixin, {
+      authenticate: function() {
+        callOrder.push('mixin');
+      }
+    }).create();
+
+  route.beforeModel();
+
+  assert.deepEqual(callOrder, ['super', 'mixin'],
+    'super#beforeModel is called before authenicate');
+});
+
+test("route respects beforeModel super priority when promise is returned", function(assert){
+  var route;
+  var callOrder = [];
+  route = Ember.Route
+    .extend({
+      beforeModel: function() {
+        return new Ember.RSVP.Promise(function(resolve){
+          Ember.run.later(function(){
+            callOrder.push('super');
+            resolve();
+          }, 20);
+        })
+      }
+    })
+    .extend(AuthenticatedRouteMixin, {
+      authenticate: function() {
+        callOrder.push('mixin');
+      }
+    }).create();
+
+  return route.beforeModel()
+    .then(function(){
+      assert.deepEqual(callOrder, ['super', 'mixin'],
+        'super#beforeModel is called before authenticate');
+    });
+});
+
+test('previously successful authentication results in successful resolution', function(assert){
+  assert.expect(1);
+  var route = createAuthenticatedRoute({
+    session: {
+      isAuthenticated: true
+    }
+  });
+
+  return route.authenticate()
+    .then(function(){
+      assert.ok(true);
+    })
+});
+
+test('attempting authentication calls fetchDefaultProvider', function(assert){
+  assert.expect(1);
+  var fetchCalled = false;
+  var route = createAuthenticatedRoute({
+    session: {
+      isAuthenticated: undefined,
+      fetch: function(){
+        fetchCalled = true;
+        return Ember.RSVP.resolve();
+      }
+    }
+  });
+  return route.authenticate()
+    .then(function(){
+      assert.ok(fetchCalled, 'fetch default provider was called');
+    });
+});
+
+test('failed authentication calls accessDenied', function(assert){
+  assert.expect(2);
+  var fetchCalled = false;
+  var accessDeniedCalled = false;
+  var route = createAuthenticatedRoute({
+    session: {
+      isAuthenticated: undefined,
+      fetch: function(){
+        fetchCalled = true;
+        return Ember.RSVP.reject();
+      }
+    },
+    accessDenied: function() {
+      accessDeniedCalled = true;
+    }
+  });
+  return route.authenticate()
+    .then(function(){
+      assert.ok(fetchCalled, 'fetch default provider was called');
+      assert.ok(accessDeniedCalled, 'accessDenied was called');
+    });
+});
+
+test('failed authentication causes accessDenied action to be sent', function(assert){
+  assert.expect(2);
+  var fetchCalled = false;
+  var sentActionName;
+  var route = createAuthenticatedRoute({
+    session: {
+      isAuthenticated: undefined,
+      fetch: function(){
+        fetchCalled = true;
+        return Ember.RSVP.reject();
+      }
+    }
+  });
+  return route.authenticate({
+    send: function(actionName) {
+      sentActionName = actionName;
+    }
+  })
+    .then(function(){
+      assert.ok(fetchCalled, 'fetch default provider was called');
+      assert.equal(sentActionName, 'accessDenied', 'accessDenied action was sent');
+    });
+});
+
+function createAuthenticatedRoute(attrs) {
+  return Ember.Router.extend(AuthenticatedRouteMixin, attrs).create()
+}


### PR DESCRIPTION
This PR is a follow up to a conversation that @mixonic and I had via Slack about eliminating the need for adding a route mixin to make routes ensure they have authentication. Please, consider this a rough draft. 

This PR provides function called `authenticatedRoute` that can be used in Router map to mark specific routes as requiring authentication. Here is an example:

```js
import Ember from 'ember';
import config from './config/environment';
var Router = Ember.Router.extend({
  location: config.locationType
});

export default Router.map(function() {
  this.authenticatedRoute('add');
});
```

When at least one `authenticatedRoute` route is present, the app will automatically attempt to `checkLogin` which will call `session.fetch`. To reduce boilerplate, I added a `sessionProvider` property to Torii config which allows to set which session provider should be fetched: ie. `this.session.fetch(config.sessionProvider)`

What do you think about this?

Questions:
~~1. Currently, the user has to overwrite `accessDenied` on each route. Should we take that from ApplicationRoute? or maybe send a `accessDenied` action?~~
~~2. What do you think about `sessionProvider`?~~

## TODO

- [x] `authenticatedRoute` function 
- [x] Test mixin is not added if sessionName is not specified
- [x] Test mixin is added when sessionName is specified
- [x] Test `checkLogin` is not called when there are no `authentictedRoutes`
- [x] Test `checkLogin` is called with `authenticatedRoutes` present
- [x] Test `accessDenied` hook is called when access is denied
- [x] Test session is retrieved
- [x] Test session.fetchDefaultProvider
- [x] Add authenticatedRoute Router DSL Extension
- [x] Add test for Router DSL Extension
- [x] Ensure accessDenied action is sent to transition
- [x] Add documentation to README
- [x] Remove code targeting < Ember 1.12
- [x] Use container lookup to get the application adapter instead of `sessionProvider` key