### PR TITLE
Updates Torii singletons to services

### DIFF
--- a/lib/torii/bootstrap/session.js
+++ b/lib/torii/bootstrap/session.js
@@ -1,10 +1,11 @@
-import Session from 'torii/session';
+import ToriiSessionService from 'torii/services/torii-session';
 
 export default function(container, sessionName){
-  container.register('torii:session', Session);
-  container.injection('torii:session', 'torii', 'torii:main');
-  container.injection('route',      sessionName, 'torii:session');
-  container.injection('controller', sessionName, 'torii:session');
+  var sessionFactoryName = 'service:' + sessionName;
+  container.register(sessionFactoryName, ToriiSessionService);
+  container.injection(sessionFactoryName, 'torii', 'service:torii');
+  container.injection('route',      sessionName, sessionFactoryName);
+  container.injection('controller', sessionName, sessionFactoryName);
 
   return container;
 }

--- a/lib/torii/bootstrap/torii.js
+++ b/lib/torii/bootstrap/torii.js
@@ -1,4 +1,3 @@
-import Torii from 'torii/torii';
 import LinkedInOauth2Provider from 'torii/providers/linked-in-oauth2';
 import GoogleOauth2Provider from 'torii/providers/google-oauth2';
 import GoogleOauth2BearerProvider from 'torii/providers/google-oauth2-bearer';
@@ -11,10 +10,12 @@ import AzureAdOauth2Provider from 'torii/providers/azure-ad-oauth2';
 import StripeConnectProvider from 'torii/providers/stripe-connect';
 import EdmodoConnectProvider from 'torii/providers/edmodo-connect';
 
+import ToriiService from 'torii/services/torii';
 import PopupService from 'torii/services/popup';
 
-export default function(container){
-  container.register('torii:main', Torii);
+export default function(container) {
+  container.register('service:torii', ToriiService);
+
   container.register('torii-provider:linked-in-oauth2', LinkedInOauth2Provider);
   container.register('torii-provider:google-oauth2', GoogleOauth2Provider);
   container.register('torii-provider:google-oauth2-bearer', GoogleOauth2BearerProvider);

--- a/lib/torii/initializers/initialize-torii-session.js
+++ b/lib/torii/initializers/initialize-torii-session.js
@@ -8,7 +8,9 @@ export default {
   initialize: function(container){
     if (configuration.sessionServiceName) {
       bootstrapSession(container, configuration.sessionServiceName);
-      container.injection('adapter', configuration.sessionServiceName, 'torii:session');
+
+      var sessionFactoryName = 'service:' + configuration.sessionServiceName;
+      container.injection('adapter', configuration.sessionServiceName, sessionFactoryName);
     }
   }
 };

--- a/lib/torii/initializers/initialize-torii.js
+++ b/lib/torii/initializers/initialize-torii.js
@@ -5,7 +5,7 @@ var initializer = {
   name: 'torii',
   initialize: function(container, app){
     bootstrapTorii(container);
-    app.inject('route', 'torii', 'torii:main');
+    app.inject('route', 'torii', 'service:torii');
   }
 };
 

--- a/lib/torii/services/torii-session.js
+++ b/lib/torii/services/torii-session.js
@@ -11,7 +11,7 @@ function lookupAdapter(container, authenticationType){
   return adapter;
 }
 
-var Session = Ember.ObjectProxy.extend({
+export default Ember.Service.extend(Ember._ProxyMixin, {
   state: null,
 
   stateMachine: computed(function(){
@@ -96,5 +96,3 @@ var Session = Ember.ObjectProxy.extend({
   }
 
 });
-
-export default Session;

--- a/lib/torii/services/torii.js
+++ b/lib/torii/services/torii.js
@@ -40,7 +40,7 @@ function proxyToProvider(methodName, requireMethod){
  *
  * @class Torii
  */
-var Torii = Ember.Object.extend({
+export default Ember.Service.extend({
 
   /**
    * Open an authorization against an API. A promise resolving
@@ -75,5 +75,3 @@ var Torii = Ember.Object.extend({
    */
   close:  proxyToProvider('close')
 });
-
-export default Torii;

--- a/test-support/helpers/torii.js
+++ b/test-support/helpers/torii.js
@@ -1,5 +1,5 @@
 export function stubValidSession(application,currentUser) {
-  var session = application.__container__.lookup('torii:session');
+  var session = application.__container__.lookup('service:session');
   var sm = session.get('stateMachine');
   Ember.run(function() {
     sm.transitionTo('authenticated');

--- a/test/tests/acceptance/ember-init-test.js
+++ b/test/tests/acceptance/ember-init-test.js
@@ -18,7 +18,7 @@ module('Ember Initialization - Acceptance', {
 test('session is not injected by default', function(){
   app = startApp();
   container = app.__container__;
-  ok(!container.has('torii:session'));
+  ok(!container.has('service:session'));
 
   container.register('controller:application', Ember.Controller.extend());
   var controller = container.lookup('controller:application');
@@ -30,7 +30,7 @@ test('session is injected with the name in the configuration', function(){
 
   app = startApp({loadInitializers: true});
   container = app.__container__;
-  ok(container.has('torii:session'), 'torii:session is injected');
+  ok(container.has('service:wackySessionName'), 'service:wackySessionName is injected');
 
   container.register('controller:application', Ember.Controller.extend());
   var controller = container.lookup('controller:application');
@@ -40,4 +40,22 @@ test('session is injected with the name in the configuration', function(){
 
   ok(!controller.get('session'),
      'Controller does not have "session" property name');
+});
+
+test('session is injectable using inject.service', function(){
+  configuration.sessionServiceName = 'session';
+
+  app = startApp({loadInitializers: true});
+  container = app.__container__;
+  ok(container.has('service:session'), 'service:session is injected');
+
+  container.register('component:testComponent', Ember.Component.extend({
+    session: Ember.inject.service('session'),
+    torii: Ember.inject.service('torii')
+  }));
+
+  var component = container.lookupFactory('component:testComponent').create();
+
+  ok(component.get('session'), 'Component has access to injected session service');
+  ok(component.get('torii'), 'Component has access to injected torii service');
 });

--- a/test/tests/acceptance/session-test.js
+++ b/test/tests/acceptance/session-test.js
@@ -15,8 +15,8 @@ module('Session - Acceptance', {
   setup: function(){
     app = startApp({loadInitializers: true});
     container = app.__container__;
-    torii   = container.lookup("torii:main");
-    session = container.lookup("torii:session");
+    torii   = container.lookup("service:torii");
+    session = container.lookup("service:session");
     adapter = container.lookup("torii-adapter:application");
 
     container.register('torii-provider:dummy-failure', DummyFailureProvider);

--- a/test/tests/acceptance/torii-helper-test.js
+++ b/test/tests/acceptance/torii-helper-test.js
@@ -15,18 +15,18 @@ module('Testing Helper - Acceptance', {
 
 
 test("sessions are not authenticated by default", function(){
-  session = container.lookup("torii:session");
+  session = container.lookup("service:session");
   ok(!session.get('isAuthenticated'),"session is not authenticated");
 });
 
 test("#stubValidSession should stub a session that isAuthenticated", function(){
   stubValidSession(app, { id : 42 });
-  session = container.lookup("torii:session");
+  session = container.lookup("service:session");
   ok(session.get('isAuthenticated'),"session is authenticated");
 });
 
 test("#stubValidSession should stub a session with the userData supplied", function(){
   stubValidSession(app, { id : 42 });
-  session = container.lookup("torii:session");
+  session = container.lookup("service:session");
   equal(session.get('currentUser.id'), 42,"session contains the correct currentUser");
 });

--- a/test/tests/integration/providers/azure-ad-oauth2-test.js
+++ b/test/tests/integration/providers/azure-ad-oauth2-test.js
@@ -18,7 +18,7 @@ module('AzureAd - Integration', {
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
-    torii = container.lookup("torii:main");
+    torii = container.lookup("service:torii");
     configuration.providers['azure-ad-oauth2'] = { apiKey: 'dummy' };
   },
   teardown: function(){

--- a/test/tests/integration/providers/edmodo-connect-test.js
+++ b/test/tests/integration/providers/edmodo-connect-test.js
@@ -19,7 +19,7 @@ module('Edmodo Connect - Integration', {
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
-    torii = container.lookup("torii:main");
+    torii = container.lookup("service:torii");
     configuration.providers['edmodo-connect'] = {
       apiKey: 'dummy',
       redirectUri: 'some url'

--- a/test/tests/integration/providers/facebook-connect-test.js
+++ b/test/tests/integration/providers/facebook-connect-test.js
@@ -11,7 +11,7 @@ var originalConfiguration = configuration.providers['facebook-connect'],
 module('Facebook Connect - Integration', {
   setup: function(){
     container = toriiContainer();
-    torii = container.lookup('torii:main');
+    torii = container.lookup('service:torii');
     configuration.providers['facebook-connect'] = {appId: 'dummy'};
     window.FB = buildFBMock();
   },

--- a/test/tests/integration/providers/facebook-oauth2-test.js
+++ b/test/tests/integration/providers/facebook-oauth2-test.js
@@ -18,7 +18,7 @@ module('Facebook OAuth2 - Integration', {
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
-    torii = container.lookup("torii:main");
+    torii = container.lookup("service:torii");
     configuration.providers['facebook-oauth2'] = {apiKey: 'dummy'};
   },
   teardown: function(){

--- a/test/tests/integration/providers/github-oauth2-test.js
+++ b/test/tests/integration/providers/github-oauth2-test.js
@@ -18,7 +18,7 @@ module('Github - Integration', {
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
-    torii = container.lookup("torii:main");
+    torii = container.lookup("service:torii");
     configuration.providers['github-oauth2'] = {apiKey: 'dummy'};
   },
   teardown: function(){

--- a/test/tests/integration/providers/google-oauth2-bearer-test.js
+++ b/test/tests/integration/providers/google-oauth2-bearer-test.js
@@ -19,7 +19,7 @@ module('Google Bearer- Integration', {
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
-    torii = container.lookup("torii:main");
+    torii = container.lookup("service:torii");
     configuration.providers['google-oauth2-bearer'] = {apiKey: 'dummy'};
   },
   teardown: function(){

--- a/test/tests/integration/providers/google-oauth2-test.js
+++ b/test/tests/integration/providers/google-oauth2-test.js
@@ -19,7 +19,7 @@ module('Google - Integration', {
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
-    torii = container.lookup("torii:main");
+    torii = container.lookup("service:torii");
     configuration.providers['google-oauth2'] = {apiKey: 'dummy'};
   },
   teardown: function(){

--- a/test/tests/integration/providers/linked-in-oauth2-test.js
+++ b/test/tests/integration/providers/linked-in-oauth2-test.js
@@ -18,7 +18,7 @@ module('Linked In - Integration', {
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
-    torii = container.lookup("torii:main");
+    torii = container.lookup("service:torii");
     configuration.providers['linked-in-oauth2'] = {apiKey: 'dummy'};
   },
   teardown: function(){

--- a/test/tests/integration/providers/oauth1-test.js
+++ b/test/tests/integration/providers/oauth1-test.js
@@ -24,7 +24,7 @@ module('Oauth1 - Integration', {
 
     container.register('torii-provider:'+providerName, OAuth1Provider);
 
-    torii = container.lookup("torii:main");
+    torii = container.lookup("service:torii");
     configuration.providers[providerName] = {requestTokenUri: requestTokenUri};
   },
   teardown: function(){

--- a/test/tests/integration/providers/stripe-connect-test.js
+++ b/test/tests/integration/providers/stripe-connect-test.js
@@ -18,7 +18,7 @@ module('Stripe Connect - Integration', {
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
-    torii = container.lookup("torii:main");
+    torii = container.lookup("service:torii");
     configuration.providers['stripe-connect'] = {apiKey: 'dummy'};
   },
   teardown: function(){

--- a/test/tests/integration/session-test.js
+++ b/test/tests/integration/session-test.js
@@ -1,7 +1,7 @@
 var container, session, user, adapter;
 
 import toriiContainer from 'test/helpers/torii-container';
-import Session from 'torii/session';
+import SessionService from 'torii/services/torii-session';
 import DummyAdapter from 'test/helpers/dummy-adapter';
 import DummySuccessProvider from 'test/helpers/dummy-success-provider';
 import DummyFailureProvider from 'test/helpers/dummy-failure-provider';
@@ -9,11 +9,11 @@ import DummyFailureProvider from 'test/helpers/dummy-failure-provider';
 module('Session (open) - Integration', {
   setup: function(){
     container = toriiContainer();
-    container.register('torii:session', Session);
+    container.register('service:session', SessionService);
     container.register('torii-provider:dummy-success', DummySuccessProvider);
     container.register('torii-provider:dummy-failure', DummyFailureProvider);
-    container.injection('torii:session', 'torii', 'torii:main');
-    session = container.lookup('torii:session');
+    container.injection('service:session', 'torii', 'service:torii');
+    session = container.lookup('service:session');
   },
   teardown: function(){
     Ember.run(container, 'destroy');
@@ -69,9 +69,9 @@ test("failed auth sets isAuthenticated to false, sets error", function(){
 module('Session (close) - Integration', {
   setup: function(){
     container = toriiContainer();
-    container.register('torii:session', Session);
-    container.injection('torii:session', 'torii', 'torii:main');
-    session = container.lookup('torii:session');
+    container.register('service:session', SessionService);
+    container.injection('service:session', 'torii', 'service:torii');
+    session = container.lookup('service:session');
     adapter = container.lookup('torii-adapter:application');
 
     // Put the session in an open state

--- a/test/tests/integration/torii-test.js
+++ b/test/tests/integration/torii-test.js
@@ -10,7 +10,7 @@ module('Torii - Integration', {
 
     container.register('torii-provider:dummy-success', DummySuccessProvider);
     container.register('torii-provider:dummy-failure', DummyFailureProvider);
-    torii = container.lookup('torii:main');
+    torii = container.lookup('service:torii');
   },
   teardown: function(){
     Ember.run(container, 'destroy');

--- a/test/tests/unit/torii-test.js
+++ b/test/tests/unit/torii-test.js
@@ -1,4 +1,4 @@
-import Torii from 'torii/torii';
+import Torii from 'torii/services/torii';
 
 module('Torii');
 


### PR DESCRIPTION
Still needs:

- [x] Test coverage of `inject.service()`
- [ ] Updates to version numbers and documentation

Opening this PR for discussion. This PR aims to bring the various Torii singletons inline with Ember Services by using the `Ember.Service` class and registering the singletons using the standard `service:*` naming scheme.

The biggest drawback to this change is breaking changes to anyone currently using the Torii singletons directly (i.e. through `container.lookup`). However, this functionality has been deprecated and the `inject` pattern has been introduced to fill that gap.

Alternatively, we could register the service under both names and maintain backwards compatibility (if this is possible). 