### PR TITLE
Add CSRF protection for OAuth2 providers via state parameter

### DIFF
--- a/lib/torii/lib/random-url-safe.js
+++ b/lib/torii/lib/random-url-safe.js
@@ -1,0 +1,11 @@
+export default function randomUrlSafe(length) {
+  var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  var result = '';
+
+  for (var i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+
+  return result;
+}
+

--- a/lib/torii/providers/azure-ad-oauth2.js
+++ b/lib/torii/providers/azure-ad-oauth2.js
@@ -25,7 +25,7 @@ var AzureAdOauth2 = Oauth2.extend({
   responseMode: configurable('responseMode', null),
 
   responseParams: computed(function () {
-    return [ this.get('responseType') ];
+    return [ this.get('responseType'), 'state' ];
   }),
 
   apiVersion: '1.0',

--- a/lib/torii/providers/azure-ad-oauth2.js
+++ b/lib/torii/providers/azure-ad-oauth2.js
@@ -18,7 +18,7 @@ var AzureAdOauth2 = Oauth2.extend({
   tennantId: configurable('tennantId', 'common'),
 
   // additional url params that this provider requires
-  requiredUrlParams: ['state', 'api-version', 'client_id'],
+  requiredUrlParams: ['api-version', 'client_id'],
 
   optionalUrlParams: ['scope', 'nonce', 'response_mode'],
 
@@ -27,8 +27,6 @@ var AzureAdOauth2 = Oauth2.extend({
   responseParams: computed(function () {
     return [ this.get('responseType') ];
   }),
-
-  state: 'STATE',
 
   apiVersion: '1.0',
 

--- a/lib/torii/providers/facebook-oauth2.js
+++ b/lib/torii/providers/facebook-oauth2.js
@@ -8,7 +8,7 @@ export default Oauth2.extend({
   // Additional url params that this provider requires
   requiredUrlParams: ['display'],
 
-  responseParams: ['code'],
+  responseParams: ['code', 'state'],
 
   scope:        configurable('scope', 'email'),
 

--- a/lib/torii/providers/github-oauth2.js
+++ b/lib/torii/providers/github-oauth2.js
@@ -10,12 +10,7 @@ var GithubOauth2 = Oauth2.extend({
   name:       'github-oauth2',
   baseUrl:    'https://github.com/login/oauth/authorize',
 
-  // additional url params that this provider requires
-  requiredUrlParams: ['state'],
-
   responseParams: ['code'],
-
-  state: 'STATE',
 
   redirectUri: configurable('redirectUri', function(){
     // A hack that allows redirectUri to be configurable

--- a/lib/torii/providers/github-oauth2.js
+++ b/lib/torii/providers/github-oauth2.js
@@ -10,7 +10,7 @@ var GithubOauth2 = Oauth2.extend({
   name:       'github-oauth2',
   baseUrl:    'https://github.com/login/oauth/authorize',
 
-  responseParams: ['code'],
+  responseParams: ['code', 'state'],
 
   redirectUri: configurable('redirectUri', function(){
     // A hack that allows redirectUri to be configurable

--- a/lib/torii/providers/google-oauth2-bearer.js
+++ b/lib/torii/providers/google-oauth2-bearer.js
@@ -12,7 +12,6 @@ var GoogleOauth2Bearer = Oauth2Bearer.extend({
   baseUrl: 'https://accounts.google.com/o/oauth2/auth',
 
   // additional params that this provider requires
-  requiredUrlParams: ['state'],
   optionalUrlParams: ['scope', 'request_visible_actions'],
 
   requestVisibleActions: configurable('requestVisibleActions', ''),
@@ -20,8 +19,6 @@ var GoogleOauth2Bearer = Oauth2Bearer.extend({
   responseParams: ['access_token'],
 
   scope: configurable('scope', 'email'),
-
-  state: configurable('state', 'STATE'),
 
   redirectUri: configurable('redirectUri',
                             'http://localhost:8000/oauth2callback')

--- a/lib/torii/providers/google-oauth2.js
+++ b/lib/torii/providers/google-oauth2.js
@@ -18,7 +18,7 @@ var GoogleOauth2 = Oauth2.extend({
 
   accessType: configurable('accessType', ''),
 
-  responseParams: ['code'],
+  responseParams: ['code', 'state'],
 
   scope: configurable('scope', 'email'),
 

--- a/lib/torii/providers/google-oauth2.js
+++ b/lib/torii/providers/google-oauth2.js
@@ -12,7 +12,6 @@ var GoogleOauth2 = Oauth2.extend({
   baseUrl: 'https://accounts.google.com/o/oauth2/auth',
 
   // additional params that this provider requires
-  requiredUrlParams: ['state'],
   optionalUrlParams: ['scope', 'request_visible_actions', 'access_type', 'approval_prompt', 'hd'],
 
   requestVisibleActions: configurable('requestVisibleActions', ''),
@@ -22,8 +21,6 @@ var GoogleOauth2 = Oauth2.extend({
   responseParams: ['code'],
 
   scope: configurable('scope', 'email'),
-
-  state: configurable('state', 'STATE'),
 
   approvalPrompt: configurable('approvalPrompt', 'auto'),
 

--- a/lib/torii/providers/linked-in-oauth2.js
+++ b/lib/torii/providers/linked-in-oauth2.js
@@ -11,7 +11,7 @@ var LinkedInOauth2 = Oauth2.extend({
   name:       'linked-in-oauth2',
   baseUrl:    'https://www.linkedin.com/uas/oauth2/authorization',
 
-  responseParams: ['code'],
+  responseParams: ['code', 'state'],
 
   redirectUri: configurable('redirectUri', function(){
     // A hack that allows redirectUri to be configurable

--- a/lib/torii/providers/linked-in-oauth2.js
+++ b/lib/torii/providers/linked-in-oauth2.js
@@ -11,12 +11,7 @@ var LinkedInOauth2 = Oauth2.extend({
   name:       'linked-in-oauth2',
   baseUrl:    'https://www.linkedin.com/uas/oauth2/authorization',
 
-  // additional url params that this provider requires
-  requiredUrlParams: ['state'],
-
   responseParams: ['code'],
-
-  state: 'STATE',
 
   redirectUri: configurable('redirectUri', function(){
     // A hack that allows redirectUri to be configurable

--- a/lib/torii/providers/oauth2-code.js
+++ b/lib/torii/providers/oauth2-code.js
@@ -136,7 +136,8 @@ var Oauth2 = Provider.extend({
         redirectUri = this.get('redirectUri'),
         responseParams = this.get('responseParams'),
         responseType = this.get('responseType'),
-        state = this.get('state');
+        state = this.get('state'),
+        shouldCheckState = responseParams.indexOf('state') !== -1;
 
     return this.get('popup').open(url, responseParams).then(function(authData){
       var missingResponseParams = [];
@@ -152,7 +153,7 @@ var Oauth2 = Provider.extend({
               "these required response params: " + responseParams.join(', '));
       }
 
-      if (authData.state !== state) {
+      if (shouldCheckState && authData.state !== state) {
         throw new Error('The response from the provider has an incorrect ' +
                         'session state param: should be "' + state + '", ' +
                         'but is "' + authData.state + '"');

--- a/lib/torii/providers/oauth2-code.js
+++ b/lib/torii/providers/oauth2-code.js
@@ -2,6 +2,7 @@ import Provider from 'torii/providers/base';
 import {configurable} from 'torii/configuration';
 import QueryString from 'torii/lib/query-string';
 import requiredProperty from 'torii/lib/required-property';
+import randomUrlSafe from 'torii/lib/random-url-safe';
 
 var computed = Ember.computed;
 
@@ -42,7 +43,7 @@ var Oauth2 = Provider.extend({
    *
    * @property {array} requiredUrlParams
    */
-  requiredUrlParams: ['response_type', 'client_id', 'redirect_uri'],
+  requiredUrlParams: ['response_type', 'client_id', 'redirect_uri', 'state'],
 
   /**
    * Parameters that may be included in the 3rd-party provider's url that we build.
@@ -68,6 +69,20 @@ var Oauth2 = Provider.extend({
 
   scope:        configurable('scope', null),
   clientId:     configurable('clientId', function () { return this.get('apiKey'); }),
+
+  state:        configurable('state', function () { return this.get('randomState'); }),
+
+  _randomState: null,
+  randomState: computed('_randomState', function() {
+    var state = this.get('_randomState');
+
+    if (!state) {
+      state = randomUrlSafe(16);
+      this.set('_randomState', state);
+    }
+
+    return state;
+  }),
 
   /**
    * The oauth response type we expect from the third party provider. Hardcoded to 'code' for oauth2-code flows
@@ -120,7 +135,8 @@ var Oauth2 = Provider.extend({
         url         = this.buildUrl(),
         redirectUri = this.get('redirectUri'),
         responseParams = this.get('responseParams'),
-        responseType = this.get('responseType');
+        responseType = this.get('responseType'),
+        state = this.get('state');
 
     return this.get('popup').open(url, responseParams).then(function(authData){
       var missingResponseParams = [];
@@ -134,6 +150,12 @@ var Oauth2 = Provider.extend({
       if (missingResponseParams.length){
         throw new Error("The response from the provider is missing " +
               "these required response params: " + responseParams.join(', '));
+      }
+
+      if (authData.state !== state) {
+        throw new Error('The response from the provider has an incorrect ' +
+                        'session state param: should be "' + state + '", ' +
+                        'but is "' + authData.state + '"');
       }
 
       return {

--- a/lib/torii/providers/stripe-connect.js
+++ b/lib/torii/providers/stripe-connect.js
@@ -9,7 +9,7 @@ export default Oauth2.extend({
   requiredUrlParams: [],
   optionalUrlParams: ['stripe_landing', 'always_prompt'],
 
-  responseParams: ['code'],
+  responseParams: ['code', 'state'],
 
   scope: configurable('scope', 'read_write'),
   stripeLanding: configurable('stripeLanding', ''),

--- a/test/helpers/mock-popup.js
+++ b/test/helpers/mock-popup.js
@@ -7,7 +7,7 @@ var MockPopup = function(options) {
   this.state = options.state;
 };
 
-MockPopup.prototype.open = function(url){
+MockPopup.prototype.open = function(url, keys){
   this.opened = true;
 
   var parser = new ParseQueryString(url, ['state']),
@@ -18,7 +18,13 @@ MockPopup.prototype.open = function(url){
     state = this.state;
   }
 
-  return Ember.RSVP.resolve({ code: 'test', state: state });
+  var response = { code: 'test' };
+
+  if (keys.indexOf('state') !== -1) {
+    response.state = state;
+  }
+
+  return Ember.RSVP.resolve(response);
 };
 
 export default MockPopup;

--- a/test/helpers/mock-popup.js
+++ b/test/helpers/mock-popup.js
@@ -1,0 +1,24 @@
+import ParseQueryString from 'torii/lib/parse-query-string';
+
+var MockPopup = function(options) {
+  options = options || {};
+
+  this.opened = false;
+  this.state = options.state;
+};
+
+MockPopup.prototype.open = function(url){
+  this.opened = true;
+
+  var parser = new ParseQueryString(url, ['state']),
+    data = parser.parse(),
+    state = data.state;
+
+  if (this.state !== undefined) {
+    state = this.state;
+  }
+
+  return Ember.RSVP.resolve({ code: 'test', state: state });
+};
+
+export default MockPopup;

--- a/test/tests/integration/providers/azure-ad-oauth2-test.js
+++ b/test/tests/integration/providers/azure-ad-oauth2-test.js
@@ -2,27 +2,26 @@ var torii, container;
 
 import toriiContainer from 'test/helpers/torii-container';
 import configuration from 'torii/configuration';
+import MockPopup from 'test/helpers/mock-popup';
 
 var originalConfiguration = configuration.providers['azure-ad-oauth2'];
 
-var opened, mockPopup = {
-  open: function(){
-    opened = true;
-    return Ember.RSVP.resolve({ 'code': 'test' });
-  }
-};
+var mockPopup = new MockPopup();
+
+var failPopup = new MockPopup({ state: 'invalid-state' });
 
 module('AzureAd - Integration', {
   setup: function(){
     container = toriiContainer();
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
+    container.register('torii-service:fail-popup', failPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
     torii = container.lookup("torii:main");
     configuration.providers['azure-ad-oauth2'] = { apiKey: 'dummy' };
   },
   teardown: function(){
-    opened = false;
+    mockPopup.opened = false;
     configuration.providers['azure-ad-oauth2'] = originalConfiguration;
     Ember.run(container, 'destroy');
   }
@@ -31,7 +30,18 @@ module('AzureAd - Integration', {
 test("Opens a popup to AzureAd", function(){
   Ember.run(function(){
     torii.open('azure-ad-oauth2').finally(function(){
-      ok(opened, "Popup service is opened");
+      ok(mockPopup.opened, "Popup service is opened");
+    });
+  });
+});
+
+test('Validates the state parameter in the response', function(){
+  container.injection('torii-provider', 'popup', 'torii-service:fail-popup');
+
+  Ember.run(function(){
+    torii.open('azure-ad-oauth2').then(null, function(e){
+      ok(/has an incorrect session state/.test(e.message),
+         'authentication fails due to invalid session state response');
     });
   });
 });

--- a/test/tests/integration/providers/facebook-oauth2-test.js
+++ b/test/tests/integration/providers/facebook-oauth2-test.js
@@ -2,27 +2,27 @@ var torii, container;
 
 import toriiContainer from 'test/helpers/torii-container';
 import configuration from 'torii/configuration';
+import MockPopup from 'test/helpers/mock-popup';
 
 var originalConfiguration = configuration.providers['facebook-oauth2'];
 
-var opened, mockPopup = {
-  open: function(){
-    opened = true;
-    return Ember.RSVP.resolve({ code: 'abc' });
-  }
-};
+var mockPopup = new MockPopup();
+
+var failPopup = new MockPopup({ state: 'invalid-state' });
+
 
 module('Facebook OAuth2 - Integration', {
   setup: function(){
     container = toriiContainer();
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
+    container.register('torii-service:fail-popup', failPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
     torii = container.lookup("torii:main");
     configuration.providers['facebook-oauth2'] = {apiKey: 'dummy'};
   },
   teardown: function(){
-    opened = false;
+    mockPopup.opened = false;
     configuration.providers['facebook-oauth2'] = originalConfiguration;
     Ember.run(container, 'destroy');
   }
@@ -31,7 +31,7 @@ module('Facebook OAuth2 - Integration', {
 test("Opens a popup to Facebook", function(){
   Ember.run(function(){
     torii.open('facebook-oauth2').finally(function(){
-      ok(opened, "Popup service is opened");
+      ok(mockPopup.opened, "Popup service is opened");
     });
   });
 });
@@ -43,6 +43,17 @@ test("Resolves with an authentication object containing 'redirectUri'", function
          'Object has redirectUri');
     }, function(err){
       ok(false, 'Failed with err '+err);
+    });
+  });
+});
+
+test('Validates the state parameter in the response', function(){
+  container.injection('torii-provider', 'popup', 'torii-service:fail-popup');
+
+  Ember.run(function(){
+    torii.open('facebook-oauth2').then(null, function(e){
+      ok(/has an incorrect session state/.test(e.message),
+         'authentication fails due to invalid session state response');
     });
   });
 });

--- a/test/tests/integration/providers/github-oauth2-test.js
+++ b/test/tests/integration/providers/github-oauth2-test.js
@@ -2,27 +2,26 @@ var torii, container;
 
 import toriiContainer from 'test/helpers/torii-container';
 import configuration from 'torii/configuration';
+import MockPopup from 'test/helpers/mock-popup';
 
 var originalConfiguration = configuration.providers['github-oauth2'];
 
-var opened, mockPopup = {
-  open: function(){
-    opened = true;
-    return Ember.RSVP.resolve({ code: 'test' });
-  }
-};
+var mockPopup = new MockPopup();
+
+var failPopup = new MockPopup({ state: 'invalid-state' });
 
 module('Github - Integration', {
   setup: function(){
     container = toriiContainer();
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
+    container.register('torii-service:fail-popup', failPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
     torii = container.lookup("torii:main");
     configuration.providers['github-oauth2'] = {apiKey: 'dummy'};
   },
   teardown: function(){
-    opened = false;
+    mockPopup.opened = false;
     configuration.providers['github-oauth2'] = originalConfiguration;
     Ember.run(container, 'destroy');
   }
@@ -31,7 +30,18 @@ module('Github - Integration', {
 test("Opens a popup to GitHub", function(){
   Ember.run(function(){
     torii.open('github-oauth2').finally(function(){
-      ok(opened, "Popup service is opened");
+      ok(mockPopup.opened, "Popup service is opened");
+    });
+  });
+});
+
+test('Validates the state parameter in the response', function(){
+  container.injection('torii-provider', 'popup', 'torii-service:fail-popup');
+
+  Ember.run(function(){
+    torii.open('github-oauth2').then(null, function(e){
+      ok(/has an incorrect session state/.test(e.message),
+         'authentication fails due to invalid session state response');
     });
   });
 });

--- a/test/tests/integration/providers/linked-in-oauth2-test.js
+++ b/test/tests/integration/providers/linked-in-oauth2-test.js
@@ -2,27 +2,26 @@ var torii, container;
 
 import toriiContainer from 'test/helpers/torii-container';
 import configuration from 'torii/configuration';
+import MockPopup from 'test/helpers/mock-popup';
 
 var originalConfiguration = configuration.providers['linked-in-oauth2'];
 
-var opened, mockPopup = {
-  open: function(){
-    opened = true;
-    return Ember.RSVP.resolve({ code: 'test' });
-  }
-};
+var mockPopup = new MockPopup();
+
+var failPopup = new MockPopup({ state: 'invalid-state' });
 
 module('Linked In - Integration', {
   setup: function(){
     container = toriiContainer();
     container.register('torii-service:mock-popup', mockPopup, {instantiate: false});
+    container.register('torii-service:fail-popup', failPopup, {instantiate: false});
     container.injection('torii-provider', 'popup', 'torii-service:mock-popup');
 
     torii = container.lookup("torii:main");
     configuration.providers['linked-in-oauth2'] = {apiKey: 'dummy'};
   },
   teardown: function(){
-    opened = false;
+    mockPopup.opened = false;
     configuration.providers['linked-in-oauth2'] = originalConfiguration;
     Ember.run(container, 'destroy');
   }
@@ -31,7 +30,18 @@ module('Linked In - Integration', {
 test("Opens a popup to Linked In", function(){
   Ember.run(function(){
     torii.open('linked-in-oauth2').finally(function(){
-      ok(opened, "Popup service is opened");
+      ok(mockPopup.opened, "Popup service is opened");
+    });
+  });
+});
+
+test('Validates the state parameter in the response', function(){
+  container.injection('torii-provider', 'popup', 'torii-service:fail-popup');
+
+  Ember.run(function(){
+    torii.open('linked-in-oauth2').then(null, function(e){
+      ok(/has an incorrect session state/.test(e.message),
+         'authentication fails due to invalid session state response');
     });
   });
 });

--- a/test/tests/unit/providers/azure-ad-oauth2-test.js
+++ b/test/tests/unit/providers/azure-ad-oauth2-test.js
@@ -30,7 +30,7 @@ test("Provider generates a URL with required config", function(){
   var expectedUrl = provider.get('baseUrl') + '?' + 'response_type=code' +
           '&client_id=' + 'abcdef' +
           '&redirect_uri=' + encodeURIComponent(provider.get('redirectUri')) +
-          '&state=STATE' +
+          '&state=' + provider.get('state') +
           '&api-version=1.0';
 
   equal(provider.buildUrl(),
@@ -47,7 +47,7 @@ test("Provider generates a URL with required config including the tennantId", fu
   var expectedUrl = provider.get('baseUrl') + '?' + 'response_type=code' +
           '&client_id=' + 'abcdef' +
           '&redirect_uri=' + encodeURIComponent(provider.get('redirectUri')) +
-          '&state=STATE' +
+          '&state=' + provider.get('state') +
           '&api-version=1.0';
 
   equal(provider.buildUrl(),
@@ -69,7 +69,7 @@ test("Provider generates a URL with required config when using id_token", functi
   var expectedUrl = provider.get('baseUrl') + '?' + 'response_type=id_token' +
           '&client_id=' + 'abcdef' +
           '&redirect_uri=' + encodeURIComponent(provider.get('redirectUri')) +
-          '&state=STATE' +
+          '&state=' + provider.get('state') +
           '&api-version=1.0' +
           '&scope=openid%20email' +
           '&response_mode=query';

--- a/test/tests/unit/providers/edmodo-connect-test.js
+++ b/test/tests/unit/providers/edmodo-connect-test.js
@@ -44,6 +44,7 @@ test("Provider generates a URL with required config", function(){
   var expectedUrl = provider.get('baseUrl') + '?' + 'response_type=token' +
           '&client_id=' + 'abcdef' +
           '&redirect_uri=' + encodeURIComponent('http://localhost:4200/edmodo/callback') +
+          '&state=' + encodeURIComponent(provider.get('state')) +
           '&scope=basic';
 
   equal(provider.buildUrl(),

--- a/test/tests/unit/providers/google-oauth2-bearer-test.js
+++ b/test/tests/unit/providers/google-oauth2-bearer-test.js
@@ -30,7 +30,7 @@ test("Provider generates a URL with required config", function(){
   var expectedUrl = provider.get('baseUrl') + '?' + 'response_type=token' +
           '&client_id=' + 'abcdef' +
           '&redirect_uri=' + encodeURIComponent(provider.get('redirectUri')) +
-          '&state=STATE' +
+          '&state=' + provider.get('state') +
           '&scope=email';
 
   equal(provider.buildUrl(),

--- a/test/tests/unit/providers/oauth2-bearer-test.js
+++ b/test/tests/unit/providers/oauth2-bearer-test.js
@@ -13,7 +13,7 @@ var Provider = BaseProvider.extend({
   responseParams: ['access_token']
 });
 
-module('MockOauth2Provider (oauth2-code subclass) - Unit', {
+module('MockOauth2Provider (oauth2-bearer subclass) - Unit', {
   setup: function(){
     configuration.providers['mock-oauth2'] = {};
     provider = new Provider();
@@ -43,7 +43,7 @@ test("Provider generates a URL with required config", function(){
   configuration.providers['mock-oauth2'] = {
     apiKey: 'dummyKey'
   };
-  equal(provider.buildUrl(), 'http://example.com?response_type=token&client_id=dummyKey&redirect_uri=http%3A%2F%2Ffoo',
+  equal(provider.buildUrl(), 'http://example.com?response_type=token&client_id=dummyKey&redirect_uri=http%3A%2F%2Ffoo&state=' + provider.get('state'),
         'generates the correct URL');
 });
 
@@ -52,7 +52,7 @@ test("Provider generates a URL with optional scope", function(){
     apiKey: 'dummyKey',
     scope: 'someScope'
   };
-  equal(provider.buildUrl(), 'http://example.com?response_type=token&client_id=dummyKey&redirect_uri=http%3A%2F%2Ffoo&scope=someScope',
+  equal(provider.buildUrl(), 'http://example.com?response_type=token&client_id=dummyKey&redirect_uri=http%3A%2F%2Ffoo&state=' + provider.get('state') + '&scope=someScope',
         'generates the correct URL');
 });
 

--- a/test/tests/unit/providers/stripe-connect-test.js
+++ b/test/tests/unit/providers/stripe-connect-test.js
@@ -2,38 +2,37 @@ var provider;
 
 import configuration from 'torii/configuration';
 
-import GoogleProvider from 'torii/providers/google-oauth2';
+import StripeConnectProvider from 'torii/providers/stripe-connect';
 
-module('Unit - GoogleAuth2Provider', {
+module('Unit - StripeConnectProvider', {
   setup: function(){
-    configuration.providers['google-oauth2'] = {};
-    provider = new GoogleProvider();
+    configuration.providers['stripe-connect'] = {};
+    provider = new StripeConnectProvider();
   },
   teardown: function(){
     Ember.run(provider, 'destroy');
-    configuration.providers['google-oauth2'] = {};
+    configuration.providers['stripe-connect'] = {};
   }
 });
 
 test("Provider requires an apiKey", function(){
-  configuration.providers['google-oauth2'] = {};
+  configuration.providers['stripe-connect'] = {};
   throws(function(){
     provider.buildUrl();
-  }, /Expected configuration value providers.google-oauth2.apiKey to be defined!/);
+  }, /Expected configuration value providers.stripe-connect.apiKey to be defined!/);
 });
 
 test("Provider generates a URL with required config", function(){
-  configuration.providers['google-oauth2'] = {
+  configuration.providers['stripe-connect'] = {
     apiKey: 'abcdef',
-    approvalPrompt: 'force'
   };
 
   var expectedUrl = provider.get('baseUrl') + '?' + 'response_type=code' +
           '&client_id=' + 'abcdef' +
           '&redirect_uri=' + encodeURIComponent(provider.get('redirectUri')) +
           '&state=' + provider.get('state') +
-          '&scope=email' +
-          '&approval_prompt=force';
+          '&scope=read_write' +
+          '&always_prompt=false';
 
   equal(provider.buildUrl(),
         expectedUrl,
@@ -41,23 +40,20 @@ test("Provider generates a URL with required config", function(){
 });
 
 test("Provider generates a URL with optional parameters", function(){
-  configuration.providers['google-oauth2'] = {
+  configuration.providers['stripe-connect'] = {
     apiKey: 'abcdef',
-    approvalPrompt: 'force',
-    requestVisibleActions: 'http://some-url.com',
-    accessType: 'offline',
-    hd: 'google.com'
+    scope: 'read_only',
+    stripeLanding: 'login',
+    alwaysPrompt: true
   };
 
   var expectedUrl = provider.get('baseUrl') + '?' + 'response_type=code' +
           '&client_id=' + 'abcdef' +
           '&redirect_uri=' + encodeURIComponent(provider.get('redirectUri')) +
           '&state=' + provider.get('state') +
-          '&scope=email' +
-          '&request_visible_actions=' + encodeURIComponent('http://some-url.com') +
-          '&access_type=offline' +
-          '&approval_prompt=force' +
-          '&hd=google.com';
+          '&scope=read_only' +
+          '&stripe_landing=login' +
+          '&always_prompt=true';
 
   equal(provider.buildUrl(),
         expectedUrl,


### PR DESCRIPTION
### Summary

The OAuth2 code provider (and all subclasses) now default to a generated random "state" URL parameter. This is transmitted to the server, and the provider validates that the same state parameter is received in the response.

This protects against Cross-Site Request Forgery. For more details on this part of the OAuth2 spec, see here RFC 6749 section 10.12:

http://tools.ietf.org/html/rfc6749#section-10.12

### Implementation

The OAuth2 code provider has a default value for `state` which generates and caches a random URL-safe string. This can be overridden by the configuration if the application requires it.

There's also a new mock popup test helper, which defaults to returning the `state` parameter from the request as part of the resolved `authData`. All relevant integration tests have been updated to use this new helper.

I also moved `buildUrl`-related integration tests for the Google and Stripe providers into unit tests, where they are easier to assert.

### Open issues

I haven't tried checking that the providers work against the real APIs, but I checked all the developer docs for the providers I updated and confirmed that they do support the state parameter as per spec.

Also not sure how to update the documentation for this change.