### PR TITLE
stubValidSession accepts session, not currentUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,29 +523,37 @@ then the session object will fall back to using the `application` adapter.
 ## Test Helpers
 
 For testing code that interacts with torii it can be useful to stub a
-valid session. Torii inculdes a test helper for this.
+valid session. Torii inculdes a test helper for stubbing sessions during
+acceptance testing.
 
-First you need to import the `stubValidSession` helper method.
+Import the `stubValidSession` helper method.
 
 ```javascript
-import {stubValidSession} from 'your-app-name/tests/helpers/torii';
+import { stubValidSession } from 'your-app-name/tests/helpers/torii';
 ```
 
-And then you can call it passing in the test `application` and the object that
-should be assigned as the `currentUser` in the session.
+Pass the test `application`, and a second argument that is treated like the
+return value from an adapter `open` or `fetch` hook. The properties become
+accessible on the session itself.
 
 ```javascript
-stubValidSession(application, {handle : 'testguy', uid : 'xyz'});
+stubValidSession(application, {
+  currentUser: {
+    handle: 'testguy',
+    uid: 'xyz'
+  }
+});
 ```
 
+A more complete example follows:
+
 ```javascript
+import { stubValidSession } from 'your-app/tests/helpers/torii';
 
-import {stubValidSession} from 'your-app/tests/helpers/torii';
-
-// test boilerplate
+/* test boilerplate */
 
 test('shows something when signed in', function(assert) {
-  stubValidSession(application, {object});
+  stubValidSession(application, {currentUser});
   visit('/');
 
   andThen(function() {

--- a/test-support/helpers/torii.js
+++ b/test-support/helpers/torii.js
@@ -1,8 +1,8 @@
-export function stubValidSession(application,currentUser) {
+export function stubValidSession(application,sessionData) {
   var session = application.__container__.lookup('service:session');
   var sm = session.get('stateMachine');
   Ember.run(function() {
-    sm.transitionTo('authenticated');
-    session.set('content.currentUser', currentUser);
+    sm.send('startOpen');
+    sm.send('finishOpen', sessionData);
   });
 }

--- a/test/tests/acceptance/torii-helper-test.js
+++ b/test/tests/acceptance/torii-helper-test.js
@@ -1,11 +1,11 @@
 import startApp from 'test/helpers/start-app';
-import {stubValidSession} from 'test-support/helpers/torii';
+import { stubValidSession } from 'test-support/helpers/torii';
 
 var app, container, session;
 
 module('Testing Helper - Acceptance', {
   setup: function(){
-    app = startApp({loadInitializers: true});
+    app = startApp({ loadInitializers: true });
     container = app.__container__;
   },
   teardown: function(){
@@ -20,13 +20,13 @@ test("sessions are not authenticated by default", function(){
 });
 
 test("#stubValidSession should stub a session that isAuthenticated", function(){
-  stubValidSession(app, { id : 42 });
+  stubValidSession(app, { id: 42 });
   session = container.lookup("service:session");
   ok(session.get('isAuthenticated'),"session is authenticated");
 });
 
 test("#stubValidSession should stub a session with the userData supplied", function(){
-  stubValidSession(app, { id : 42 });
+  stubValidSession(app, { id: 42 });
   session = container.lookup("service:session");
-  equal(session.get('currentUser.id'), 42,"session contains the correct currentUser");
+  equal(session.get('id'), 42,"session contains the correct currentUser");
 });


### PR DESCRIPTION
Torii is agnostic about `currentUser` or any other property being available on the session. Instead, a generic payload can be provided when stubbing session state for acceptance tests.