### PR TITLE
Allow unregistered factorys to require authentication

### DIFF
--- a/lib/torii/bootstrap/routing.js
+++ b/lib/torii/bootstrap/routing.js
@@ -1,17 +1,25 @@
 import ApplicationRouteMixin from 'torii/routing/application-route-mixin';
 import AuthenticatedRouteMixin from 'torii/routing/authenticated-route-mixin';
 
+var AuthenticatedRoute = null;
+
+function reopenOrRegister(container, factoryName, mixin) {
+  var factory = container.lookup(factoryName);
+  if (factory) {
+    factory.reopen(mixin);
+  } else {
+    if (!AuthenticatedRoute) {
+      AuthenticatedRoute = Ember.Route.extend(AuthenticatedRouteMixin);
+    }
+    container.register(factoryName, AuthenticatedRoute);
+  }
+}
+
 export default function(container, authenticatedRoutes){
-
-  var ApplicationRoute = container.lookup('route:application');
-  ApplicationRoute.reopen(ApplicationRouteMixin);
-
+  reopenOrRegister(container, 'route:application', ApplicationRouteMixin);
   for (var i = 0; i < authenticatedRoutes.length; i++) {
     var routeName = authenticatedRoutes[i];
     var factoryName = 'route:' + routeName;
-    var routeClass = container.lookup(factoryName);
-    routeClass.reopen(AuthenticatedRouteMixin);
+    reopenOrRegister(container, factoryName, AuthenticatedRouteMixin);
   }
-
-  return container;
 }

--- a/lib/torii/lib/container-utils.js
+++ b/lib/torii/lib/container-utils.js
@@ -1,0 +1,3 @@
+export function registerFactory(container, factoryName, factory) {
+  container.register(factoryName, factory);
+}

--- a/test/tests/acceptance/routing-test.js
+++ b/test/tests/acceptance/routing-test.js
@@ -97,6 +97,26 @@ test('authenticated routes get authenticate method', function(assert){
   });
 });
 
+test('lazyily created authenticated routes get authenticate method', function(assert){
+  assert.expect(2);
+  configuration.sessionServiceName = 'session';
+
+  var checkLoginCalled = false;
+
+  return bootApp({
+    map: function() {
+      this.route('home');
+      this.authenticatedRoute('account');
+    }
+  }).then(function(){
+    var applicationRoute = app.__container__.lookup('route:application');
+    var authenticatedRoute = app.__container__.lookup('route:account');
+
+    assert.ok(applicationRoute.checkLogin, "checkLogin function is present");
+    assert.ok(authenticatedRoute.authenticate, "authenticate function is present");
+  });
+});
+
 function bootApp(attrs) {
   var map = attrs.map || function(){};
   var containerSetup = attrs.container || function() {};


### PR DESCRIPTION
Routing options should not require that the factory actually be present in the container when bootstrapping.