### PR TITLE
Honor `route:basic` convention for generated routes.

### DIFF
--- a/lib/torii/bootstrap/routing.js
+++ b/lib/torii/bootstrap/routing.js
@@ -5,11 +5,14 @@ var AuthenticatedRoute = null;
 
 function reopenOrRegister(container, factoryName, mixin) {
   var factory = container.lookup(factoryName);
+  var basicFactory;
+  
   if (factory) {
     factory.reopen(mixin);
   } else {
+    basicFactory = container.lookupFactory('route:basic');
     if (!AuthenticatedRoute) {
-      AuthenticatedRoute = Ember.Route.extend(AuthenticatedRouteMixin);
+      AuthenticatedRoute = basicFactory.extend(AuthenticatedRouteMixin);
     }
     container.register(factoryName, AuthenticatedRoute);
   }


### PR DESCRIPTION
By default Ember uses `route:basic` if a route for the specific routename is not found. This emulates that behavior...