### PR TITLE
Ember 2.1 compat

### DIFF
--- a/lib/torii/bootstrap/routing.js
+++ b/lib/torii/bootstrap/routing.js
@@ -1,28 +1,29 @@
 import ApplicationRouteMixin from 'torii/routing/application-route-mixin';
 import AuthenticatedRouteMixin from 'torii/routing/authenticated-route-mixin';
+import { lookup, lookupFactory, register } from 'torii/lib/container-utils';
 
 var AuthenticatedRoute = null;
 
-function reopenOrRegister(container, factoryName, mixin) {
-  var factory = container.lookup(factoryName);
+function reopenOrRegister(applicationInstance, factoryName, mixin) {
+  var factory = lookup(applicationInstance, factoryName);
   var basicFactory;
-  
+
   if (factory) {
     factory.reopen(mixin);
   } else {
-    basicFactory = container.lookupFactory('route:basic');
+    basicFactory = lookupFactory(applicationInstance, 'route:basic');
     if (!AuthenticatedRoute) {
       AuthenticatedRoute = basicFactory.extend(AuthenticatedRouteMixin);
     }
-    container._registry.register(factoryName, AuthenticatedRoute);
+    register(applicationInstance, factoryName, AuthenticatedRoute);
   }
 }
 
-export default function(container, authenticatedRoutes){
-  reopenOrRegister(container, 'route:application', ApplicationRouteMixin);
+export default function(applicationInstance, authenticatedRoutes){
+  reopenOrRegister(applicationInstance, 'route:application', ApplicationRouteMixin);
   for (var i = 0; i < authenticatedRoutes.length; i++) {
     var routeName = authenticatedRoutes[i];
     var factoryName = 'route:' + routeName;
-    reopenOrRegister(container, factoryName, AuthenticatedRouteMixin);
+    reopenOrRegister(applicationInstance, factoryName, AuthenticatedRouteMixin);
   }
 }

--- a/lib/torii/configuration.js
+++ b/lib/torii/configuration.js
@@ -4,7 +4,10 @@ var configuration       = get(window, 'ENV.torii') || {};
 configuration.providers = configuration.providers || {};
 
 function configurable(configKey, defaultValue){
-  return Ember.computed(function(){
+  return Ember.computed(function configurableComputed(){
+    // Trigger super wrapping in Ember 2.1.
+    // See: https://github.com/emberjs/ember.js/pull/12359
+    this._super = this._super || (function(){ throw new Error('should always have _super'); })();
     var namespace = this.get('configNamespace'),
         fullKey   = namespace ? [namespace, configKey].join('.') : configKey,
         value     = get(configuration, fullKey);

--- a/lib/torii/instance-initializers/setup-routes.js
+++ b/lib/torii/instance-initializers/setup-routes.js
@@ -11,7 +11,7 @@ export default {
         var authenticatedRoutes = router.router.authenticatedRoutes;
         var hasAuthenticatedRoutes = !Ember.isEmpty(authenticatedRoutes);
         if (hasAuthenticatedRoutes) {
-          bootstrapRouting(applicationInstance.container, authenticatedRoutes);
+          bootstrapRouting(applicationInstance, authenticatedRoutes);
         }
         router.off('willTransition', setupRoutes);
       };

--- a/lib/torii/lib/container-utils.js
+++ b/lib/torii/lib/container-utils.js
@@ -1,15 +1,27 @@
-export function lookupFactory(application, name) {
-  if (application && application.lookupFactory) {
-    return application.lookupFactory(name);
+export function register(applicationInstance, name, factory) {
+  if (applicationInstance && applicationInstance.application) {
+    return applicationInstance.application.register(name, factory);
   } else {
-    return application.__container__.lookupFactory(name);
+    return applicationInstance.registry.register(name, factory);
   }
 }
 
-export function lookup(application, name) {
-  if (application && application.lookup) {
-    return application.lookup(name);
+export function lookupFactory(applicationInstance, name) {
+  if (applicationInstance && applicationInstance.lookupFactory) {
+    return applicationInstance.lookupFactory(name);
+  } else if (applicationInstance && applicationInstance.application) {
+    return applicationInstance.application.__container__.lookupFactory(name);
   } else {
-    return application.__container__.lookup(name);
+    return applicationInstance.container.lookupFactory(name);
+  }
+}
+
+export function lookup(applicationInstance, name) {
+  if (applicationInstance && applicationInstance.lookup) {
+    return applicationInstance.lookup(name);
+  } else if (applicationInstance && applicationInstance.application) {
+    return applicationInstance.application.__container__.lookup(name);
+  } else {
+    return applicationInstance.container.lookup(name);
   }
 }

--- a/lib/torii/lib/parse-query-string.js
+++ b/lib/torii/lib/parse-query-string.js
@@ -1,7 +1,6 @@
 export default Ember.Object.extend({
-  init: function(url, validKeys) {
-    this.url = url;
-    this.validKeys = validKeys;
+  init: function() {
+    this.validKeys = this.keys;
   },
 
   parse: function(){

--- a/lib/torii/lib/query-string.js
+++ b/lib/torii/lib/query-string.js
@@ -33,10 +33,10 @@ function getOptionalParamValue(obj, paramName){
 }
 
 export default Ember.Object.extend({
-  init: function(obj, urlParams, optionalUrlParams){
-    this.obj               = obj;
-    this.urlParams         = Ember.A(urlParams).uniq();
-    this.optionalUrlParams = Ember.A(optionalUrlParams || []).uniq();
+  init: function() {
+    this.obj               = this.provider;
+    this.urlParams         = Ember.A(this.requiredParams).uniq();
+    this.optionalUrlParams = Ember.A(this.optionalParams || []).uniq();
 
     this.optionalUrlParams.forEach(function(param){
       if (this.urlParams.indexOf(param) > -1) {
@@ -45,7 +45,7 @@ export default Ember.Object.extend({
     }, this);
   },
 
-  toString: function(){
+  toString: function() {
     var urlParams         = this.urlParams,
         optionalUrlParams = this.optionalUrlParams,
         obj               = this.obj,

--- a/lib/torii/providers/azure-ad-oauth2.js
+++ b/lib/torii/providers/azure-ad-oauth2.js
@@ -32,7 +32,7 @@ var AzureAdOauth2 = Oauth2.extend({
 
   responseType: configurable('responseType', 'code'),
 
-  redirectUri: configurable('redirectUri', function(){
+  redirectUri: configurable('redirectUri', function azureRedirectUri(){
     // A hack that allows redirectUri to be configurable
     // but default to the superclass
     return this._super();

--- a/lib/torii/providers/oauth2-code.js
+++ b/lib/torii/providers/oauth2-code.js
@@ -101,7 +101,7 @@ var Oauth2 = Provider.extend({
   */
   responseParams: requiredProperty(),
 
-  redirectUri: computed(function(){
+  redirectUri: computed(function defaultRedirectUri(){
     return currentUrl();
   }),
 
@@ -109,7 +109,11 @@ var Oauth2 = Provider.extend({
     var requiredParams = this.get('requiredUrlParams'),
         optionalParams = this.get('optionalUrlParams');
 
-    var qs = new QueryString(this, requiredParams, optionalParams);
+    var qs = QueryString.create({
+      provider: this,
+      requiredParams: requiredParams,
+      optionalParams: optionalParams
+    });
     return qs.toString();
   },
 

--- a/lib/torii/redirect-handler.js
+++ b/lib/torii/redirect-handler.js
@@ -11,10 +11,6 @@ import { CURRENT_REQUEST_KEY } from "./services/popup";
 
 var RedirectHandler = Ember.Object.extend({
 
-  init: function(windowObject){
-    this.windowObject = windowObject;
-  },
-
   run: function(){
     var windowObject = this.windowObject;
 
@@ -37,7 +33,7 @@ var RedirectHandler = Ember.Object.extend({
 RedirectHandler.reopenClass({
   // untested
   handle: function(windowObject){
-    var handler = new RedirectHandler(windowObject);
+    var handler = RedirectHandler.create({windowObject: windowObject});
     return handler.run();
   }
 });

--- a/lib/torii/services/popup.js
+++ b/lib/torii/services/popup.js
@@ -41,17 +41,15 @@ function prepareOptions(options){
 }
 
 function parseMessage(url, keys){
-  var parser = new ParseQueryString(url, keys),
+  var parser = ParseQueryString.create({url: url, keys: keys}),
       data = parser.parse();
   return data;
 }
 
 var Popup = Ember.Object.extend(Ember.Evented, {
 
-  init: function(options){
-    this._super.apply(this, arguments);
-    options = options || {};
-    this.popupIdGenerator = options.popupIdGenerator || UUIDGenerator;
+  init: function() {
+    this.popupIdGenerator = this.popupIdGenerator || UUIDGenerator;
   },
 
   // Open a popup window. Returns a promise that resolves or rejects

--- a/test/helpers/mock-popup.js
+++ b/test/helpers/mock-popup.js
@@ -10,7 +10,7 @@ var MockPopup = function(options) {
 MockPopup.prototype.open = function(url, keys){
   this.opened = true;
 
-  var parser = new ParseQueryString(url, ['state']),
+  var parser = ParseQueryString.create({url: url, keys: ['state']}),
     data = parser.parse(),
     state = data.state;
 

--- a/test/tests/acceptance/ember-init-test.js
+++ b/test/tests/acceptance/ember-init-test.js
@@ -1,9 +1,13 @@
 import startApp from 'test/helpers/start-app';
 import configuration from 'torii/configuration';
-import {
-  lookup,
-  lookupFactory
-} from 'torii/lib/container-utils';
+
+function lookup(app, key) {
+  return app.__container__.lookup(key);
+}
+
+function lookupFactory(app, key) {
+  return app.__container__.lookupFactory(key);
+}
 
 var app, originalSessionServiceName;
 

--- a/test/tests/acceptance/routing-test.js
+++ b/test/tests/acceptance/routing-test.js
@@ -1,7 +1,10 @@
 import startApp from 'test/helpers/start-app';
 import configuration from 'torii/configuration';
 import AuthenticatedRouteMixin from 'torii/routing/authenticated-route-mixin';
-import { lookup } from 'torii/lib/container-utils';
+
+function lookup(app, key) {
+  return app.__container__.lookup(key);
+}
 
 var app, originalSessionServiceName;
 
@@ -41,7 +44,7 @@ test('ApplicationRoute#checkLogin is not called when no authenticated routes are
   applicationRoute.beforeModel();
   assert.ok(routesConfigured, 'Router map was called');
   assert.ok(!checkLoginCalled, 'checkLogin was not called');
-})
+});
 
 test('ApplicationRoute#checkLogin is called when an authenticated route is present', function(assert){
   assert.expect(2);

--- a/test/tests/unit/adapters/dummy-test.js
+++ b/test/tests/unit/adapters/dummy-test.js
@@ -4,7 +4,7 @@ var adapter;
 
 module("DummyAdapter - Unit", {
   setup: function(){
-    adapter = new DummyAdapter();
+    adapter = DummyAdapter.create();
   },
   teardown: function() {
     Ember.run(adapter, 'destroy');

--- a/test/tests/unit/configuration-test.js
+++ b/test/tests/unit/configuration-test.js
@@ -17,7 +17,7 @@ var originalConfiguration = configuration.test,
 
 module('Configuration - Unit', {
   setup: function(){
-    testable = new Testable();
+    testable = Testable.create();
   },
   teardown: function(){
     configuration.test = originalConfiguration;

--- a/test/tests/unit/lib/parse-query-string-test.js
+++ b/test/tests/unit/lib/parse-query-string-test.js
@@ -6,7 +6,7 @@ module('ParseQueryString - Unit');
 
 test('parses each passed key', function(){
   var url = 'http://localhost.dev:3000/xyz/?code=abcdef';
-  var parser = new ParseQueryString(url, ['code']);
+  var parser = ParseQueryString.create({url: url, keys: ['code']});
 
   var result = parser.parse();
   ok(result.code, 'gets code');
@@ -15,7 +15,7 @@ test('parses each passed key', function(){
 
 test('parses keys without the hash fragment', function(){
   var url = 'http://localhost.dev:3000/xyz/?code=abcdef#notCode=other';
-  var parser = new ParseQueryString(url, ['code']);
+  var parser = ParseQueryString.create({url: url, keys: ['code']});
 
   var result = parser.parse();
   ok(result.code, 'gets code');
@@ -24,7 +24,7 @@ test('parses keys without the hash fragment', function(){
 
 test('parses multiple keys', function(){
   var url = 'http://localhost.dev:3000/xyz/?oauth_token=xxx&oauth_verifier=yyy';
-  var parser = new ParseQueryString(url, ['oauth_token','oauth_verifier']);
+  var parser = ParseQueryString.create({url: url, keys: ['oauth_token','oauth_verifier']});
 
   var result = parser.parse();
   ok(result.oauth_token, 'gets token');

--- a/test/tests/unit/lib/query-string-test.js
+++ b/test/tests/unit/lib/query-string-test.js
@@ -25,14 +25,14 @@ module('QueryString - Unit', {
 });
 
 test('looks up properties by camelized name', function(){
-  var qs = new QueryString(obj, ['client_id']);
+  var qs = QueryString.create({provider: obj, requiredParams: ['client_id']});
 
   equal(qs.toString(), 'client_id='+clientId,
         'sets client_id from clientId property');
 });
 
 test('joins properties with "&"', function(){
-  var qs = new QueryString(obj, ['client_id','response_type']);
+  var qs = QueryString.create({provider: obj, requiredParams: ['client_id','response_type']});
 
   equal(qs.toString(),
         'client_id='+clientId+'&response_type='+responseType,
@@ -40,7 +40,7 @@ test('joins properties with "&"', function(){
 });
 
 test('url encodes values', function(){
-  var qs = new QueryString(obj, ['redirect_uri']);
+  var qs = QueryString.create({provider: obj, requiredParams: ['redirect_uri']});
 
   equal(qs.toString(),
         'redirect_uri=http%3A%2F%2Flocalhost.dev%3A3000%2Fxyz%2Fpdq',
@@ -48,7 +48,7 @@ test('url encodes values', function(){
 });
 
 test('throws error if property exists as non-camelized form', function(){
-  var qs = new QueryString(obj, ['additional_param']);
+  var qs = QueryString.create({provider: obj, requiredParams: ['additional_param']});
 
   throws(function(){
     qs.toString();
@@ -57,7 +57,7 @@ test('throws error if property exists as non-camelized form', function(){
 });
 
 test('throws error if property does not exist', function(){
-  var qs = new QueryString(obj, ['nonexistent_property']);
+  var qs = QueryString.create({provider: obj, requiredParams: ['nonexistent_property']});
 
   throws(function(){
     qs.toString();
@@ -66,7 +66,11 @@ test('throws error if property does not exist', function(){
 });
 
 test('no error thrown when specifying optional properties that do not exist', function(){
-  var qs = new QueryString(obj, [], ['nonexistent_property']);
+  var qs = QueryString.create({
+    provider: obj,
+    requiredParams: [],
+    optionalParams: ['nonexistent_property']
+  });
 
   equal(qs.toString(), '',
         'empty query string with nonexistent optional param');
@@ -74,7 +78,11 @@ test('no error thrown when specifying optional properties that do not exist', fu
 });
 
 test('optional properties is added if it does exist', function(){
-  var qs = new QueryString(obj, [], ['optional_property']);
+  var qs = QueryString.create({
+    provider: obj,
+    requiredParams: [],
+    optionalParams: ['optional_property']
+  });
 
   equal(qs.toString(), 'optional_property='+optionalProperty,
         'optional_property is populated when the value is there');
@@ -82,7 +90,10 @@ test('optional properties is added if it does exist', function(){
 });
 
 test('value of false gets into url', function(){
-  var qs = new QueryString(obj, ['false_prop']);
+  var qs = QueryString.create({
+    provider: obj,
+    requiredParams: ['false_prop']
+  });
 
   equal(qs.toString(), 'false_prop=false',
         'false_prop is in url even when false');
@@ -90,14 +101,21 @@ test('value of false gets into url', function(){
 });
 
 test('uniq-ifies required params', function(){
-  var qs = new QueryString(obj, ['client_id', 'client_id']);
+  var qs = QueryString.create({
+    provider: obj,
+    requiredParams: ['client_id', 'client_id']
+  });
 
   equal(qs.toString(), 'client_id='+clientId,
         'only includes client_id once');
 });
 
 test('uniq-ifies optional params', function(){
-  var qs = new QueryString(obj, [], ['client_id', 'client_id']);
+  var qs = QueryString.create({
+    provider: obj,
+    requiredParams: [],
+    optionalParams: ['client_id', 'client_id']
+  });
 
   equal(qs.toString(), 'client_id='+clientId,
         'only includes client_id once');
@@ -105,6 +123,10 @@ test('uniq-ifies optional params', function(){
 
 test('throws if optionalParams includes any requiredParams', function(){
   throws(function(){
-    var qs = new QueryString(obj, ['client_id'], ['client_id']);
+    var qs = QueryString.create({
+      provider: obj,
+      requiredParams: ['client_id'],
+      optionalParams: ['client_id']
+    });
   }, /required parameters cannot also be optional/i);
 });

--- a/test/tests/unit/providers/azure-ad-oauth2-test.js
+++ b/test/tests/unit/providers/azure-ad-oauth2-test.js
@@ -7,7 +7,7 @@ import AzureAdProvider from 'torii/providers/azure-ad-oauth2';
 module('Unit - AzureAdOAuth2Provider', {
   setup: function(){
     configuration.providers['azure-ad-oauth2'] = {};
-    provider = new AzureAdProvider();
+    provider = AzureAdProvider.create();
   },
   teardown: function(){
     Ember.run(provider, 'destroy');

--- a/test/tests/unit/providers/dummy-failure-test.js
+++ b/test/tests/unit/providers/dummy-failure-test.js
@@ -4,7 +4,7 @@ import Provider from 'test/helpers/dummy-failure-provider';
 
 module('DummyFailureProvider - Unit', {
   setup: function(){
-    provider = new Provider();
+    provider = Provider.create();
   },
   teardown: function(){
     Ember.run(provider, 'destroy');

--- a/test/tests/unit/providers/dummy-success-test.js
+++ b/test/tests/unit/providers/dummy-success-test.js
@@ -4,7 +4,7 @@ import Provider from 'test/helpers/dummy-success-provider';
 
 module('DummySuccessProvider - Unit', {
   setup: function(){
-    provider = new Provider();
+    provider = Provider.create();
   },
   teardown: function(){
     Ember.run(provider, 'destroy');

--- a/test/tests/unit/providers/edmodo-connect-test.js
+++ b/test/tests/unit/providers/edmodo-connect-test.js
@@ -7,7 +7,7 @@ import EdmodoConnectProvider from 'torii/providers/edmodo-connect';
 module('Unit - EdmodoConnectProvider', {
   setup: function(){
     configuration.providers['edmodo-connect'] = {};
-    provider = new EdmodoConnectProvider();
+    provider = EdmodoConnectProvider.create();
   },
   teardown: function(){
     Ember.run(provider, 'destroy');

--- a/test/tests/unit/providers/google-oauth2-bearer-test.js
+++ b/test/tests/unit/providers/google-oauth2-bearer-test.js
@@ -7,7 +7,7 @@ import GoogleBearerProvider from 'torii/providers/google-oauth2-bearer';
 module('Unit - GoogleAuth2BearerProvider', {
   setup: function(){
     configuration.providers['google-oauth2-bearer'] = {};
-    provider = new GoogleBearerProvider();
+    provider = GoogleBearerProvider.create();
   },
   teardown: function(){
     Ember.run(provider, 'destroy');

--- a/test/tests/unit/providers/google-oauth2-test.js
+++ b/test/tests/unit/providers/google-oauth2-test.js
@@ -7,7 +7,7 @@ import GoogleProvider from 'torii/providers/google-oauth2';
 module('Unit - GoogleAuth2Provider', {
   setup: function(){
     configuration.providers['google-oauth2'] = {};
-    provider = new GoogleProvider();
+    provider = GoogleProvider.create();
   },
   teardown: function(){
     Ember.run(provider, 'destroy');

--- a/test/tests/unit/providers/oauth1-test.js
+++ b/test/tests/unit/providers/oauth1-test.js
@@ -17,7 +17,7 @@ var Provider = BaseProvider.extend({
 module('MockOauth1Provider (oauth1 subclass) - Unit', {
   setup: function(){
     configuration.providers['mock-oauth1'] = {};
-    provider = new Provider();
+    provider = Provider.create();
   },
   teardown: function(){
     Ember.run(provider, 'destroy');

--- a/test/tests/unit/providers/oauth2-bearer-test.js
+++ b/test/tests/unit/providers/oauth2-bearer-test.js
@@ -16,7 +16,7 @@ var Provider = BaseProvider.extend({
 module('MockOauth2Provider (oauth2-bearer subclass) - Unit', {
   setup: function(){
     configuration.providers['mock-oauth2'] = {};
-    provider = new Provider();
+    provider = Provider.create();
   },
   teardown: function(){
     Ember.run(provider, 'destroy');

--- a/test/tests/unit/providers/oauth2-code-test.js
+++ b/test/tests/unit/providers/oauth2-code-test.js
@@ -25,8 +25,8 @@ var TokenProvider = BaseProvider.extend({
 module('MockOauth2Provider (oauth2-code subclass) - Unit', {
   setup: function(){
     configuration.providers['mock-oauth2'] = {};
-    provider = new Provider();
-    tokenProvider = new TokenProvider();
+    provider = Provider.create();
+    tokenProvider = TokenProvider.create();
   },
   teardown: function(){
     Ember.run(provider, 'destroy');

--- a/test/tests/unit/providers/stripe-connect-test.js
+++ b/test/tests/unit/providers/stripe-connect-test.js
@@ -7,7 +7,7 @@ import StripeConnectProvider from 'torii/providers/stripe-connect';
 module('Unit - StripeConnectProvider', {
   setup: function(){
     configuration.providers['stripe-connect'] = {};
-    provider = new StripeConnectProvider();
+    provider = StripeConnectProvider.create();
   },
   teardown: function(){
     Ember.run(provider, 'destroy');

--- a/test/tests/unit/redirect-handler-test.js
+++ b/test/tests/unit/redirect-handler-test.js
@@ -35,13 +35,13 @@ test("handles a tori-popup window with a current request key in localStorage and
     if (key === CURRENT_REQUEST_KEY) {
       return keyForReturn;
     }
-  }
+  };
   mockWindow.localStorage.setItem = function(key, val) {
     if (key === keyForReturn) {
       equal(val, url, 'url is set for parent window');
     }
-  }
-  var handler = new RedirectHandler(mockWindow);
+  };
+  var handler = RedirectHandler.create({windowObject: mockWindow});
 
   Ember.run(function(){
     handler.run().then(function(){}, function(error){
@@ -55,7 +55,7 @@ test("handles a tori-popup window with a current request key in localStorage and
 test('rejects the promise if there is no request key', function(){
 
   var mockWindow = buildMockWindow("", "http://authServer?code=1234512345fw");
-  var handler = new RedirectHandler(mockWindow);
+  var handler = RedirectHandler.create({windowObject: mockWindow});
 
   Ember.run(function(){
     handler.run().then(function(){
@@ -71,9 +71,9 @@ test('does not set local storage when not a torii popup', function(){
   var mockWindow = buildMockWindow("", "http://authServer?code=1234512345fw");
   mockWindow.localStorage.setItem = function(key, value) {
     ok(false, "storage was set unexpectedly");
-  }
+  };
 
-  var handler = new RedirectHandler(mockWindow);
+  var handler = RedirectHandler.create({windowObject: mockWindow});
 
   Ember.run(function(){
     handler.run().then(function(){
@@ -92,9 +92,9 @@ test('closes the window when a torii popup with request', function(){
     if (key === CURRENT_REQUEST_KEY) {
       return 'some-key';
     }
-  }
+  };
 
-  var handler = new RedirectHandler(mockWindow);
+  var handler = RedirectHandler.create({windowObject: mockWindow});
 
   mockWindow.close = function(){
     ok(true, "Window was closed");
@@ -110,7 +110,7 @@ test('does not close the window when a not torii popup', function(){
 
   var mockWindow = buildMockWindow("", "http://authServer?code=1234512345fw");
 
-  var handler = new RedirectHandler(mockWindow);
+  var handler = RedirectHandler.create({windowObject: mockWindow});
 
   mockWindow.close = function(){
     ok(false, "Window was closed unexpectedly");

--- a/test/tests/unit/services/popup-test.js
+++ b/test/tests/unit/services/popup-test.js
@@ -33,7 +33,7 @@ var buildMockStorageEvent = function(popupId, redirectUrl){
 
 module("Popup - Unit", {
   setup: function(){
-    popup = new Popup();
+    popup = Popup.create();
     localStorage.removeItem(CURRENT_REQUEST_KEY);
   },
   teardown: function(){
@@ -50,7 +50,7 @@ asyncTest("open resolves based on popup window", function(){
   var popupId = '09123-asdf';
   var mockWindow = null
 
-  popup = new Popup({popupIdGenerator: buildPopupIdGenerator(popupId)});
+  popup = Popup.create({popupIdGenerator: buildPopupIdGenerator(popupId)});
 
   window.open = function(url, name){
     ok(true, 'calls window.open');


### PR DESCRIPTION
Compat with Ember 2.1 primarily calls for:

* Use only the public object invocation syntax of `.create`, not `new`. `new` is private and changes in 2.1.
* Expect `applicationInstance` object instead of containers
* Add hack to work around https://github.com/emberjs/ember.js/pull/12359