### PR TITLE
Pass _initRouterJs arguments to _super.

### DIFF
--- a/lib/torii/router-dsl-ext.js
+++ b/lib/torii/router-dsl-ext.js
@@ -11,7 +11,7 @@ proto.authenticatedRoute = function() {
 Router.reopen({
   _initRouterJs: function() {
     currentMap = [];
-    this._super();
+    this._super.apply(this, arguments);
     this.router.authenticatedRoutes = currentMap;
   }
 });


### PR DESCRIPTION
The incorrect `_super` call here breaks loading substate code that depends on the `moduleBasedResolver` flag: http://git.io/vnEeC