### PR TITLE
Ensure that `session.attemptedTransition` is set

### DIFF
--- a/lib/torii/routing/authenticated-route-mixin.js
+++ b/lib/torii/routing/authenticated-route-mixin.js
@@ -15,18 +15,23 @@ export default Ember.Mixin.create({
   authenticate: function (transition) {
     var route = this,
       session = this.get(configuration.sessionServiceName),
-      isAuthenticated = this.get(configuration.sessionServiceName + '.isAuthenticated');
-    if (isAuthenticated === undefined) {
+      isAuthenticated = this.get(configuration.sessionServiceName + '.isAuthenticated'),
+      hasAttemptedAuth = isAuthenticated !== undefined;
+
+    if (!isAuthenticated) {
       session.attemptedTransition = transition;
-      return session.fetch()
-        .catch(function() {
-          return route.accessDenied(transition);
-        });
-    } else if (isAuthenticated) {
+
+      if (hasAttemptedAuth) {
+        return route.accessDenied(transition);
+      } else {
+        return session.fetch()
+          .catch(function() {
+            return route.accessDenied(transition);
+          });
+      }
+    } else {
       // no-op; cause the user is already authenticated
       return Ember.RSVP.resolve();
-    } else {
-      return this.accessDenied(transition);
     }
   },
   accessDenied: function (transition) {


### PR DESCRIPTION
The `session.attemptedTransition` property is currently set by the authenticated route mixin in its
`authenticate` method when `isAuthenticated === undefined`. `isAuthenticated` will only be `undefined` before the first attempt to `fetch` the session by the adapter. After that initial attempt, `isAuthenticated` will either be boolean `false` or `true`.

This changes the setting of `attemptedTransition` to happen regardless
of whether we have previously attempted to fetch authentication or not,
ensuring that upstream routes will be able to `attemptedTransition.retry()` to return to the route the user had been attempting to visit while unauthenticated.