### PR TITLE
add demoUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "bower.json"
   ],
   "ember-addon": {
-    "main": "ember-addon/index.js"
+    "main": "ember-addon/index.js",
+    "demoUrl": "http://vestorly.github.io/torii/demo.html"
   },
   "devDependencies": {
     "connect-redirection": "0.0.1",


### PR DESCRIPTION
Add a demoUrl for emberobserver. See https://twitter.com/EmberObserver/status/605909565264109569 for reference.