### PR TITLE
Iframe Service

### DIFF
--- a/ember-addon/index.js
+++ b/ember-addon/index.js
@@ -20,9 +20,14 @@ module.exports = {
     var instanceInitializers = new Funnel(tree, {
       srcDir: 'instance-initializers',
       destDir: 'instance-initializers'
-    })
+    });
 
-    return mergeTrees([initializers, instanceInitializers]);
+    var components = new Funnel(tree, {
+      srcDir: 'app-components',
+      destDir: 'components'
+    });
+
+    return mergeTrees([initializers, instanceInitializers, components]);
   },
 
   treeForAddon: function treeForAddon() {

--- a/lib/torii/app-components/torii-iframe-placeholder.js
+++ b/lib/torii/app-components/torii-iframe-placeholder.js
@@ -1,0 +1,4 @@
+import toriiIframePlaceholder from 'torii/components/torii-iframe-placeholder';
+
+export default toriiIframePlaceholder;
+

--- a/lib/torii/bootstrap/torii.js
+++ b/lib/torii/bootstrap/torii.js
@@ -35,13 +35,6 @@ export default function(application) {
   application.register('torii-service:iframe', IframeService);
   application.register('torii-service:popup', PopupService);
 
-  var remoteServiceName = configuration.remoteServiceName || 'popup';
-  if(remoteServiceName === 'iframe'){
-    application.inject('torii-provider', 'popup', 'torii-service:iframe');
-  }else{
-    application.inject('torii-provider', 'popup', 'torii-service:popup');
-  }
-
   if (window.DS) {
     var storeFactoryName = 'store:main';
     if (hasRegistration(application, 'service:store')) {

--- a/lib/torii/bootstrap/torii.js
+++ b/lib/torii/bootstrap/torii.js
@@ -9,9 +9,11 @@ import GithubOauth2Provider from 'torii/providers/github-oauth2';
 import AzureAdOauth2Provider from 'torii/providers/azure-ad-oauth2';
 import StripeConnectProvider from 'torii/providers/stripe-connect';
 import EdmodoConnectProvider from 'torii/providers/edmodo-connect';
+import configuration from 'torii/configuration';
 
 import ToriiService from 'torii/services/torii';
 import PopupService from 'torii/services/popup';
+import IframeService from 'torii/services/iframe';
 
 import { hasRegistration } from 'torii/lib/container-utils';
 
@@ -30,9 +32,15 @@ export default function(application) {
   application.register('torii-provider:edmodo-connect', EdmodoConnectProvider);
   application.register('torii-adapter:application', ApplicationAdapter);
 
+  application.register('torii-service:iframe', IframeService);
   application.register('torii-service:popup', PopupService);
 
-  application.inject('torii-provider', 'popup', 'torii-service:popup');
+  var remoteServiceName = configuration.remoteServiceName || 'popup';
+  if(remoteServiceName === 'iframe'){
+    application.inject('torii-provider', 'popup', 'torii-service:iframe');
+  }else{
+    application.inject('torii-provider', 'popup', 'torii-service:popup');
+  }
 
   if (window.DS) {
     var storeFactoryName = 'store:main';

--- a/lib/torii/components/torii-iframe-placeholder.js
+++ b/lib/torii/components/torii-iframe-placeholder.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['torii-iframe-placeholder']
+});

--- a/lib/torii/instance-initializers/walk-providers.js
+++ b/lib/torii/instance-initializers/walk-providers.js
@@ -9,7 +9,11 @@ export default {
     // like facebook-connect a chance to load up assets.
     for (var key in  configuration.providers) {
       if (configuration.providers.hasOwnProperty(key)) {
-        lookup(applicationInstance, 'torii-provider:'+key);
+        var provider = lookup(applicationInstance, 'torii-provider:'+key);
+        var provider_config = configuration.providers[key];
+        if(provider_config.remoteServiceName){
+          provider.set('popup', lookup(applicationInstance, 'torii-service:'+provider_config.remoteServiceName));
+        }
       }
     }
 

--- a/lib/torii/instance-initializers/walk-providers.js
+++ b/lib/torii/instance-initializers/walk-providers.js
@@ -7,13 +7,9 @@ export default {
     // Walk all configured providers and eagerly instantiate
     // them. This gives providers with initialization side effects
     // like facebook-connect a chance to load up assets.
-    for (var key in  configuration.providers) {
+    for (var key in configuration.providers) {
       if (configuration.providers.hasOwnProperty(key)) {
-        var provider = lookup(applicationInstance, 'torii-provider:'+key);
-        var provider_config = configuration.providers[key];
-        if(provider_config.remoteServiceName){
-          provider.set('popup', lookup(applicationInstance, 'torii-service:'+provider_config.remoteServiceName));
-        }
+        lookup(applicationInstance, 'torii-provider:'+key);
       }
     }
 

--- a/lib/torii/lib/container-utils.js
+++ b/lib/torii/lib/container-utils.js
@@ -33,3 +33,11 @@ export function lookup(applicationInstance, name) {
     return applicationInstance.container.lookup(name);
   }
 }
+
+export function getOwner(instance) {
+  if (Ember.getOwner) {
+    return Ember.getOwner(instance);
+  } else {
+    return instance.container;
+  }
+}

--- a/lib/torii/mixins/ui-service-mixin.js
+++ b/lib/torii/mixins/ui-service-mixin.js
@@ -1,0 +1,128 @@
+import UUIDGenerator from 'torii/lib/uuid-generator';
+import PopupIdSerializer from 'torii/lib/popup-id-serializer';
+import ParseQueryString from 'torii/lib/parse-query-string';
+export var CURRENT_REQUEST_KEY = '__torii_request';
+
+var on = Ember.on;
+
+function parseMessage(url, keys){
+  var parser = ParseQueryString.create({url: url, keys: keys});
+  var data = parser.parse();
+  return data;
+}
+
+var ServicesMixin = Ember.Mixin.create({
+
+  init: function(){
+    this._super.apply(this, arguments);
+    this.remoteIdGenerator = this.remoteIdGenerator || UUIDGenerator;
+  },
+
+  // Open a remote window. Returns a promise that resolves or rejects
+  // accoring to if the iframe is redirected with arguments in the URL.
+  //
+  // For example, an OAuth2 request:
+  //
+  // iframe.open('http://some-oauth.com', ['code']).then(function(data){
+  //   // resolves with data.code, as from http://app.com?code=13124
+  // });
+  //
+  // Services that use this mixin should implement openRemote
+  //
+  open: function(url, keys, options){
+    var service   = this,
+        lastRemote = this.remote;
+
+    return new Ember.RSVP.Promise(function(resolve, reject){
+      if (lastRemote) {
+        service.close();
+      }
+
+      var remoteId = service.remoteIdGenerator.generate();
+
+      var pendingRequestKey = PopupIdSerializer.serialize(remoteId);
+      localStorage.setItem(CURRENT_REQUEST_KEY, pendingRequestKey);
+
+
+      service.openRemote(url, pendingRequestKey, options);
+      service.schedulePolling();
+
+      if (service.remote && !service.remote.closed) {
+        service.remote.focus();
+      } else {
+        reject(new Error(
+          'remote could not open or was closed'));
+        return;
+      }
+
+      service.one('didClose', function(){
+        var pendingRequestKey = localStorage.getItem(CURRENT_REQUEST_KEY);
+        if (pendingRequestKey) {
+          localStorage.removeItem(pendingRequestKey);
+          localStorage.removeItem(CURRENT_REQUEST_KEY);
+        }
+        // If we don't receive a message before the timeout, we fail. Normally,
+        // the message will be received and the window will close immediately.
+        service.timeout = Ember.run.later(service, function() {
+          reject(new Error("remote was closed, authorization was denied, or a authentication message otherwise not received before the window closed."));
+        }, 100);
+      });
+
+      Ember.$(window).on('storage.torii', function(event){
+        var storageEvent = event.originalEvent;
+
+        var remoteIdFromEvent = PopupIdSerializer.deserialize(storageEvent.key);
+        if (remoteId === remoteIdFromEvent){
+          var data = parseMessage(storageEvent.newValue, keys);
+          localStorage.removeItem(storageEvent.key);
+          Ember.run(function() {
+            resolve(data);
+          });
+        }
+      });
+
+
+    }).finally(function(){
+      // didClose will reject this same promise, but it has already resolved.
+      service.close();
+
+      Ember.$(window).off('storage.torii');
+    });
+  },
+
+  close: function(){
+    if (this.remote) {
+      this.closeRemote();
+      this.remote = null;
+      this.trigger('didClose');
+    }
+    this.cleanUp();
+  },
+
+  cleanUp: function(){
+    this.clearTimeout();
+  },
+
+
+  schedulePolling: function(){
+    this.polling = Ember.run.later(this, function(){
+      this.pollRemote();
+      this.schedulePolling();
+    }, 35);
+  },
+
+  // Clear the timeout, in case it hasn't fired.
+  clearTimeout: function(){
+    Ember.run.cancel(this.timeout);
+    this.timeout = null;
+  },
+
+  stopPolling: on('didClose', function(){
+    Ember.run.cancel(this.polling);
+  })
+
+
+
+});
+
+export default ServicesMixin;

--- a/lib/torii/providers/base.js
+++ b/lib/torii/providers/base.js
@@ -1,4 +1,9 @@
 import requiredProperty from 'torii/lib/required-property';
+import { getOwner } from 'torii/lib/container-utils';
+import { configurable } from 'torii/configuration';
+import configuration from 'torii/configuration';
+
+var DEFAULT_REMOTE_SERVICE_NAME = 'popup';
 
 var computed = Ember.computed;
 
@@ -19,9 +24,21 @@ var Base = Ember.Object.extend({
    * that holds config information for this provider.
    * @property {string} configNamespace
    */
-  configNamespace: computed('name', function(){
+  configNamespace: computed('name', function() {
     return 'providers.'+this.get('name');
-  })
+  }),
+
+  popup: computed('configuredRemoteServiceName', function() {
+    var owner = getOwner(this);
+    var remoteServiceName = (
+      this.get('configuredRemoteServiceName') ||
+      configuration.remoteServiceName ||
+      DEFAULT_REMOTE_SERVICE_NAME
+    );
+    return owner.lookup('torii-service:'+remoteServiceName);
+  }),
+
+  configuredRemoteServiceName: configurable('remoteServiceName', null)
 
 });
 

--- a/lib/torii/providers/oauth1.js
+++ b/lib/torii/providers/oauth1.js
@@ -25,11 +25,11 @@ var Oauth1 = Provider.extend({
     return requestTokenUri;
   },
 
-  open: function(){
+  open: function(options){
     var name        = this.get('name'),
         url         = this.buildRequestTokenUrl();
 
-    return this.get('popup').open(url, ['code']).then(function(authData){
+    return this.get('popup').open(url, ['code'], options).then(function(authData){
       authData.provider = name;
       return authData;
     });

--- a/lib/torii/providers/oauth2-bearer.js
+++ b/lib/torii/providers/oauth2-bearer.js
@@ -13,13 +13,13 @@ var Oauth2Bearer = Provider.extend({
    * If there was an error or the user either canceled the authorization or
    * closed the popup window, the promise rejects.
    */
-  open: function(){
+  open: function(options){
     var name        = this.get('name'),
         url         = this.buildUrl(),
         redirectUri = this.get('redirectUri'),
         responseParams = this.get('responseParams');
 
-    return this.get('popup').open(url, responseParams).then(function(authData){
+    return this.get('popup').open(url, responseParams, options).then(function(authData){
       var missingResponseParams = [];
 
       responseParams.forEach(function(param){

--- a/lib/torii/providers/oauth2-code.js
+++ b/lib/torii/providers/oauth2-code.js
@@ -134,7 +134,7 @@ var Oauth2 = Provider.extend({
    * If there was an error or the user either canceled the authorization or
    * closed the popup window, the promise rejects.
    */
-  open: function(){
+  open: function(options){
     var name        = this.get('name'),
         url         = this.buildUrl(),
         redirectUri = this.get('redirectUri'),
@@ -143,7 +143,7 @@ var Oauth2 = Provider.extend({
         state = this.get('state'),
         shouldCheckState = responseParams.indexOf('state') !== -1;
 
-    return this.get('popup').open(url, responseParams).then(function(authData){
+    return this.get('popup').open(url, responseParams, options).then(function(authData){
       var missingResponseParams = [];
 
       responseParams.forEach(function(param){

--- a/lib/torii/redirect-handler.js
+++ b/lib/torii/redirect-handler.js
@@ -7,7 +7,8 @@
  */
 
 import PopupIdSerializer from "./lib/popup-id-serializer";
-import { CURRENT_REQUEST_KEY } from "./services/popup";
+import { CURRENT_REQUEST_KEY } from "./mixins/ui-service-mixin";
+import configuration from 'torii/configuration';
 
 var RedirectHandler = Ember.Object.extend({
 
@@ -21,7 +22,12 @@ var RedirectHandler = Ember.Object.extend({
         var url = windowObject.location.toString();
         windowObject.localStorage.setItem(pendingRequestKey, url);
 
-        windowObject.close();
+        var remoteServiceName = configuration.remoteServiceName || 'popup';
+        if(remoteServiceName === 'popup'){
+          // NOTE : If a single provider has been configured to use the 'iframe'
+          // service, this next line will still be called. It will just fail silently.
+          windowObject.close();
+        }
       } else{
         reject('Not a torii popup');
       }

--- a/lib/torii/services/iframe.js
+++ b/lib/torii/services/iframe.js
@@ -1,0 +1,26 @@
+import UiServiceMixin from 'torii/mixins/ui-service-mixin';
+import UUIDGenerator from 'torii/lib/uuid-generator';
+
+var on = Ember.on;
+
+var Iframe = Ember.Object.extend(Ember.Evented, UiServiceMixin, {
+
+  openRemote: function(url, pendingRequestKey, options){
+    this.remote = Ember.$('<iframe src="'+url+'" id="torii-iframe"></iframe>');
+    var iframeParent = '.torii-iframe-placeholder';
+    Ember.$(iframeParent).append(this.remote);
+  },
+
+  closeRemote: function(){
+    this.remote.remove();
+  },
+
+  pollRemote: function(){
+    if (Ember.$('#torii-iframe').length === 0) {
+      this.trigger('didClose');
+    }
+  }
+
+});
+
+export default Iframe;

--- a/lib/torii/services/popup.js
+++ b/lib/torii/services/popup.js
@@ -1,8 +1,5 @@
-import ParseQueryString from 'torii/lib/parse-query-string';
+import UiServiceMixin from 'torii/mixins/ui-service-mixin';
 import UUIDGenerator from 'torii/lib/uuid-generator';
-import PopupIdSerializer from 'torii/lib/popup-id-serializer';
-
-export var CURRENT_REQUEST_KEY = '__torii_request';
 
 var on = Ember.on;
 
@@ -40,120 +37,25 @@ function prepareOptions(options){
   }, options);
 }
 
-function parseMessage(url, keys){
-  var parser = ParseQueryString.create({url: url, keys: keys}),
-      data = parser.parse();
-  return data;
-}
+var Popup = Ember.Object.extend(Ember.Evented, UiServiceMixin, {
 
-var Popup = Ember.Object.extend(Ember.Evented, {
-
-  init: function() {
-    this.popupIdGenerator = this.popupIdGenerator || UUIDGenerator;
+  // Open a popup window.
+  openRemote: function(url, pendingRequestKey, options){
+    var optionsString = stringifyOptions(prepareOptions(options || {}));
+    this.remote = window.open(url, pendingRequestKey, optionsString);
   },
 
-  // Open a popup window. Returns a promise that resolves or rejects
-  // accoring to if the popup is redirected with arguments in the URL.
-  //
-  // For example, an OAuth2 request:
-  //
-  // popup.open('http://some-oauth.com', ['code']).then(function(data){
-  //   // resolves with data.code, as from http://app.com?code=13124
-  // });
-  //
-  open: function(url, keys, options){
-    var service   = this,
-        lastPopup = this.popup;
-
-
-    return new Ember.RSVP.Promise(function(resolve, reject){
-      if (lastPopup) {
-        service.close();
-      }
-
-      var popupId = service.popupIdGenerator.generate();
-
-      var optionsString = stringifyOptions(prepareOptions(options || {}));
-      var pendingRequestKey = PopupIdSerializer.serialize(popupId);
-      localStorage.setItem(CURRENT_REQUEST_KEY, pendingRequestKey);
-      service.popup = window.open(url, pendingRequestKey, optionsString);
-
-      if (service.popup && !service.popup.closed) {
-        service.popup.focus();
-      } else {
-        reject(new Error(
-          'Popup could not open or was closed'));
-        return;
-      }
-
-      service.one('didClose', function(){
-        var pendingRequestKey = localStorage.getItem(CURRENT_REQUEST_KEY);
-        if (pendingRequestKey) {
-          localStorage.removeItem(pendingRequestKey);
-          localStorage.removeItem(CURRENT_REQUEST_KEY);
-        }
-        // If we don't receive a message before the timeout, we fail. Normally,
-        // the message will be received and the window will close immediately.
-        service.timeout = Ember.run.later(service, function() {
-          reject(new Error("Popup was closed, authorization was denied, or a authentication message otherwise not received before the window closed."));
-        }, 100);
-      });
-
-      Ember.$(window).on('storage.torii', function(event){
-        var storageEvent = event.originalEvent;
-
-        var popupIdFromEvent = PopupIdSerializer.deserialize(storageEvent.key);
-        if (popupId === popupIdFromEvent){
-          var data = parseMessage(storageEvent.newValue, keys);
-          localStorage.removeItem(storageEvent.key);
-          Ember.run(function() {
-            resolve(data);
-          });
-        }
-      });
-
-      service.schedulePolling();
-
-    }).finally(function(){
-      // didClose will reject this same promise, but it has already resolved.
-      service.close();
-      service.clearTimeout();
-      Ember.$(window).off('storage.torii');
-    });
+  closeRemote: function(){
   },
 
-  close: function(){
-    if (this.popup) {
-      this.popup = null;
-      this.trigger('didClose');
-    }
-  },
-
-  pollPopup: function(){
-    if (!this.popup) {
+  pollRemote: function(){
+    if (!this.remote) {
       return;
     }
-    if (this.popup.closed) {
+    if (this.remote.closed) {
       this.trigger('didClose');
     }
-  },
-
-  schedulePolling: function(){
-    this.polling = Ember.run.later(this, function(){
-      this.pollPopup();
-      this.schedulePolling();
-    }, 35);
-  },
-
-  // Clear the timeout, in case it hasn't fired.
-  clearTimeout: function(){
-    Ember.run.cancel(this.timeout);
-    this.timeout = null;
-  },
-
-  stopPolling: on('didClose', function(){
-    Ember.run.cancel(this.polling);
-  }),
+  }
 
 });
 

--- a/test/tests/unit/bootstrap/torii-test.js
+++ b/test/tests/unit/bootstrap/torii-test.js
@@ -1,21 +1,59 @@
 import toriiContainer from 'test/helpers/torii-container';
+import BaseProvider from 'torii/providers/base';
+import IframeService from 'torii/services/iframe';
+import PopupService from 'torii/services/popup';
+import configuration from 'torii/configuration';
 
-var container, registry;
+var container, registry, FooProvider;
 
 module("boostrapTorii", {
-  teardown: function(){
+  setup: function() {
+    FooProvider = BaseProvider.extend({
+      name: 'foo'
+    });
+  },
+  teardown: function() {
     Ember.run(container, 'destroy');
     registry = container = null;
+    FooProvider = null;
     window.DS = null;
+    delete configuration.remoteServiceName;
+    delete configuration.providers.foo;
   }
 });
 
-test("inject popup onto providers", function(){
+test("default popup on providers", function(){
   var results = toriiContainer();
   registry = results[0];
   container = results[1];
-  registry.register('torii-provider:foo', Ember.Object.extend());
-  ok(container.lookup('torii-provider:foo').get('popup'), 'Popup is set');
+  registry.register('torii-provider:foo', FooProvider);
+  var popup = container.lookup('torii-provider:foo').get('popup');
+  ok(popup, 'Popup is set');
+  ok(popup instanceof PopupService, 'Popup service is popup');
+});
+
+test("configured default popup", function(){
+  configuration.remoteServiceName = 'iframe';
+  var results = toriiContainer();
+  registry = results[0];
+  container = results[1];
+  registry.register('torii-provider:foo', FooProvider);
+  var popup = container.lookup('torii-provider:foo').get('popup');
+  ok(popup, 'Popup is set');
+  ok(popup instanceof IframeService, 'Popup service is iframe');
+});
+
+test("configured popup on providers", function(){
+  configuration.providers.foo = {
+    remoteServiceName: 'iframe'
+  };
+  var results = toriiContainer();
+  registry = results[0];
+  container = results[1];
+  registry.register('torii-provider:foo', FooProvider);
+  var popup = container.lookup('torii-provider:foo').get('popup');
+  ok(popup, 'Popup is set');
+  ok(popup instanceof IframeService, 'Popup service is iframe');
 });
 
 test("inject legacy DS store onto providers, adapters", function(){
@@ -27,7 +65,7 @@ test("inject legacy DS store onto providers, adapters", function(){
   registry = results[0];
   container = results[1];
 
-  registry.register('torii-provider:foo', Ember.Object.extend());
+  registry.register('torii-provider:foo', FooProvider);
   var provider = container.lookup('torii-provider:foo');
   ok(provider.get('store'), 'Store is set on providers');
 
@@ -45,7 +83,7 @@ test("inject DS store onto providers, adapters", function(){
   registry = results[0];
   container = results[1];
 
-  registry.register('torii-provider:foo', Ember.Object.extend());
+  registry.register('torii-provider:foo', FooProvider);
   var provider = container.lookup('torii-provider:foo');
   ok(provider.get('store'), 'Store is set on providers');
 

--- a/test/tests/unit/redirect-handler-test.js
+++ b/test/tests/unit/redirect-handler-test.js
@@ -1,5 +1,5 @@
 import RedirectHandler from 'torii/redirect-handler';
-import { CURRENT_REQUEST_KEY } from 'torii/services/popup';
+import { CURRENT_REQUEST_KEY } from 'torii/mixins/ui-service-mixin';
 
 function buildMockWindow(windowName, url){
   return {

--- a/test/tests/unit/services/iframe-test.js
+++ b/test/tests/unit/services/iframe-test.js
@@ -1,0 +1,112 @@
+import Iframe from 'torii/services/iframe';
+import PopupIdSerializer from 'torii/lib/popup-id-serializer';
+import { CURRENT_REQUEST_KEY } from 'torii/mixins/ui-service-mixin';
+
+var iframe;
+var originalWindowOpen = window.open;
+
+var buildIframeIdGenerator = function(iframeId){
+  return {
+    generate: function(){
+      return iframeId;
+    }
+  }
+};
+
+var buildMockStorageEvent = function(iframeId, redirectUrl){
+  return Ember.$.Event('storage', {
+    originalEvent: {
+      key: PopupIdSerializer.serialize(iframeId),
+      newValue: redirectUrl
+    }
+  });
+};
+
+module("Iframe - Unit", {
+  setup: function(){
+    iframe = new Iframe();
+    localStorage.removeItem(CURRENT_REQUEST_KEY);
+  },
+  teardown: function(){
+    localStorage.removeItem(CURRENT_REQUEST_KEY);
+    window.open = originalWindowOpen;
+    Ember.$('#torii-iframe').remove();
+    Ember.run(iframe, 'destroy');
+  }
+});
+
+asyncTest("open resolves based on an embedded iframe window", function(){
+  expect(4);
+  var expectedUrl = 'http://authServer';
+  var redirectUrl = "http://localserver?code=fr"
+  var iframeId = '09123-asdf';
+  var mockWindow = null
+
+  iframe = Iframe.create({remoteIdGenerator: buildIframeIdGenerator(iframeId)});
+
+  Ember.run(function(){
+    iframe.open(expectedUrl, ['code']).then(function(data){
+      ok(true, 'resolves promise');
+      deepEqual(data, {code: 'fr'}, 'resolves with expected data');
+      equal(null,
+          localStorage.getItem(CURRENT_REQUEST_KEY),
+          "removes the key from local storage");
+      equal(null,
+          localStorage.getItem(PopupIdSerializer.serialize(iframeId)),
+          "removes the key from local storage");
+      start();
+    }, function(){
+      ok(false, 'rejected the open promise');
+      start();
+    });
+  });
+
+
+  localStorage.setItem(PopupIdSerializer.serialize(iframeId), redirectUrl);
+  // Need to manually trigger storage event, since it doesn't fire in the current window
+  Ember.$(window).trigger(buildMockStorageEvent(iframeId, redirectUrl));
+});
+
+
+
+asyncTest("open does not resolve when receiving a storage event for the wrong iframe id", function(){
+
+  var promise = Ember.run(function(){
+    return iframe.open('http://someserver.com', ['code']).then(function(data){
+      ok(false, 'resolves the open promise');
+      start();
+    }, function(){
+      ok(false, 'rejected the open promise');
+      start();
+    });
+  });
+
+  localStorage.setItem(PopupIdSerializer.serialize("invalid"), "http://authServer");
+  // Need to manually trigger storage event, since it doesn't fire in the current window
+  Ember.$(window).trigger(buildMockStorageEvent("invalid", "http://authServer"));
+
+  setTimeout(function(){
+    ok(!promise.isFulfilled, 'promise is not fulfulled by invalid data');
+    deepEqual("http://authServer",
+        localStorage.getItem(PopupIdSerializer.serialize("invalid")),
+        "doesn't remove the key from local storage");
+    start();
+  },10);
+});
+
+asyncTest("open rejects when the iframe is removed", function(){
+  
+
+  Ember.run(function(){
+    iframe.open('some-url', ['code']).then(function(){
+      ok(false, 'resolved the open promise');
+      start();
+    }, function(){
+      ok(true, 'rejected the open promise');
+      start();
+    });
+  });
+
+  Ember.$('#torii-iframe').remove();
+
+});

--- a/test/tests/unit/services/popup-test.js
+++ b/test/tests/unit/services/popup-test.js
@@ -1,6 +1,6 @@
 import Popup from 'torii/services/popup';
 import PopupIdSerializer from 'torii/lib/popup-id-serializer';
-import { CURRENT_REQUEST_KEY } from 'torii/services/popup';
+import { CURRENT_REQUEST_KEY } from 'torii/mixins/ui-service-mixin';
 
 var popup;
 var originalWindowOpen = window.open;
@@ -50,7 +50,7 @@ asyncTest("open resolves based on popup window", function(){
   var popupId = '09123-asdf';
   var mockWindow = null
 
-  popup = Popup.create({popupIdGenerator: buildPopupIdGenerator(popupId)});
+  popup = Popup.create({remoteIdGenerator: buildPopupIdGenerator(popupId)});
 
   window.open = function(url, name){
     ok(true, 'calls window.open');


### PR DESCRIPTION
This is a freshly rebased branch of https://github.com/Vestorly/torii/pull/206

The basic overview, which is described in an update to the README is:

## Using an iframe instead of a popup

You can configure torii to use an in-page iframe instead of a separate
popup window for authentication. This can be done on either a global or
a per-provider basis.

To change this globally set the `remoteServiceName` variable in the main
torii config to be `'iframe'`.

```JavaScript
/* jshint node: true */
// config/environment.js
module.exports = function(environment) {
  var ENV = {
    /* ... */
    torii: {
      remoteServiceName: 'iframe',
      providers: { /* ... */ }
    }
  };
  return ENV;
};
```

If you only want the iframe for a single provider you can include the
`remoteServiceName` value in the configuration for that provider.

```JavaScript
/* jshint node: true */
// config/environment.js
module.exports = function(environment) {
  var ENV = {
    /* ... */
    torii: {
      // a 'session' property will be injected on routes and controllers
      sessionServiceName: 'session',
      providers: {
        'mycorp-oauth2': {
          remoteServiceName: 'iframe'
          /* ... */
        }
      }
    }
  };
  return ENV;
};
```

Once your provider has been configured you need to tell torii where to
apend the iframe when you call `session.open`.

For instance:

```JavaScript
this.get("session")
  .open("mycorp-oauth2",{ iframeParent : '#signin-modal-content'})
  .then(function(){
    // ...
  });
```

Of course, the element with the id of `signin-modal-content` needs to be
currently in the DOM.

/end of README excerpt

---

Instead of requiring the `iframeParent` argument to be passed to `open` we might include a component that people can include in a template to tell torii where to put the iframe. Something like:

```handlebars
{{torii-iframe-placeholder}}
```

I took a stab at making this happen, but so far I haven't been able to get the component to be useable in the host app. I suspect that this is related to the custom build system and the fact that I don't entirely understand how it works and how it's different from ember-cli based add-ons. Would love some pointers on that note.