### PR TITLE
Sending the `transition` as a parameter with the `accessDenied` action

### DIFF
--- a/lib/torii/routing/authenticated-route-mixin.js
+++ b/lib/torii/routing/authenticated-route-mixin.js
@@ -35,6 +35,6 @@ export default Ember.Mixin.create({
     }
   },
   accessDenied: function (transition) {
-    transition.send('accessDenied');
+    transition.send('accessDenied', transition);
   }
 });

--- a/test/tests/unit/routing/authenticated-route-mixin-test.js
+++ b/test/tests/unit/routing/authenticated-route-mixin-test.js
@@ -129,6 +129,34 @@ test('failed authentication causes accessDenied action to be sent', function(ass
     });
 });
 
+test('failed authentication causes accessDenied action to be sent with transition', function(assert){
+  assert.expect(2);
+  var fetchCalled = false;
+  var sentTransition;
+  var transition = {
+    targetName: 'custom.route'
+  };
+
+  var route = createAuthenticatedRoute({
+    session: {
+      isAuthenticated: undefined,
+      fetch: function(){
+        fetchCalled = true;
+        return Ember.RSVP.reject();
+      }
+    },
+    
+    accessDenied: function(transition) {
+      sentTransition = transition;
+    }
+  });
+  return route.authenticate(transition)
+    .then(function(){
+      assert.ok(fetchCalled, 'fetch default provider was called');
+      assert.deepEqual(sentTransition, transition, 'transition was sent');
+    });
+});
+
 function createAuthenticatedRoute(attrs) {
   return Ember.Router.extend(AuthenticatedRouteMixin, attrs).create()
 }


### PR DESCRIPTION
Having the `transition` sent through the `accessDenied` action makes it much easier to redirect to the desired route after completing the normal signIn flow.