### PR TITLE
[breaking] Remove eager injection of ember-data store

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,12 +587,8 @@ authorizations. An example application adapter with an `open` hook:
 ```JavaScript
 // app/torii-adapters/application.js
 //
-// Here we will presume the store has been injected onto torii-adapter
-// factories. You would do this with an initializer, e.g.:
-//
-// application.inject('torii-adapter', 'store', 'store:main');
-//
 export default Ember.Object.extend({
+  store: Ember.inject.service(), // inject the ember-data store
 
   // The authorization argument passed in to `session.open` here is
   // the result of the `torii.open(providerName)` promise

--- a/lib/torii/bootstrap/torii.js
+++ b/lib/torii/bootstrap/torii.js
@@ -34,13 +34,4 @@ export default function(application) {
 
   application.register('torii-service:iframe', IframeService);
   application.register('torii-service:popup', PopupService);
-
-  if (window.DS) {
-    var storeFactoryName = 'store:main';
-    if (hasRegistration(application, 'service:store')) {
-      storeFactoryName = 'service:store';
-    }
-    application.inject('torii-provider', 'store', storeFactoryName);
-    application.inject('torii-adapter', 'store', storeFactoryName);
-  }
 }

--- a/lib/torii/initializers/initialize-torii.js
+++ b/lib/torii/initializers/initialize-torii.js
@@ -12,8 +12,4 @@ var initializer = {
   }
 };
 
-if (window.DS) {
-  initializer.after = 'store';
-}
-
 export default initializer;

--- a/test/tests/unit/bootstrap/torii-test.js
+++ b/test/tests/unit/bootstrap/torii-test.js
@@ -55,39 +55,3 @@ test("configured popup on providers", function(){
   ok(popup, 'Popup is set');
   ok(popup instanceof IframeService, 'Popup service is iframe');
 });
-
-test("inject legacy DS store onto providers, adapters", function(){
-  window.DS = {}; // Mock Ember-Data
-
-  var results = toriiContainer(function(registry, container) {
-    registry.register('store:main', Ember.Object.extend());
-  });
-  registry = results[0];
-  container = results[1];
-
-  registry.register('torii-provider:foo', FooProvider);
-  var provider = container.lookup('torii-provider:foo');
-  ok(provider.get('store'), 'Store is set on providers');
-
-  registry.register('torii-adapter:foo', Ember.Object.extend());
-  var adapter = container.lookup('torii-adapter:foo');
-  ok(adapter.get('store'), 'Store is set on adapters');
-});
-
-test("inject DS store onto providers, adapters", function(){
-  window.DS = {}; // Mock Ember-Data
-
-  var results = toriiContainer(function(registry, container) {
-    registry.register('service:store', Ember.Service.extend());
-  });
-  registry = results[0];
-  container = results[1];
-
-  registry.register('torii-provider:foo', FooProvider);
-  var provider = container.lookup('torii-provider:foo');
-  ok(provider.get('store'), 'Store is set on providers');
-
-  registry.register('torii-adapter:foo', Ember.Object.extend());
-  var adapter = container.lookup('torii-adapter:foo');
-  ok(adapter.get('store'), 'Store is set on adapters');
-});


### PR DESCRIPTION
Removes code that attempted to inject ember-data's store on
torii-providers and torii-adapters. Consumer code should instead use
`store: Ember.inject.service()` if their custom providers or adapters
need the store.

refs #270
refs #261