### PR TITLE
Document that `options` is passed through to the provider's methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,10 @@ A minimal provider:
 ```JavaScript
 // app/torii-providers/geocities.js
 export default Ember.Object.extend({
-  // create a new authorization
+  // Create a new authorization.
+  // When your code calls `this.get('torii').open('geocities', options)`,
+  // the `options` will be passed to this provider's `open` method.
+  
   open: function(options) {
     return new Ember.RSVP.Promise(function(resolve, reject){
       // resolve with an authorization object
@@ -486,11 +489,15 @@ export default Ember.Route.extend({
     openGeocities: function(username, password){
       var route = this;
       var providerName = 'geocities';
-      // argument to open is passed into the provider
-      this.get('torii').open(providerName, {
+
+      // The options to `this.get('torii').open(providerName, options)` will
+      // be passed to the provider's `open` method.
+      var options = {
         username: username,
         password: password
-      }).then(function(authorization){
+      };
+      
+      this.get('torii').open(providerName, options).then(function(authorization){
         // authorization as returned by the provider
         route.somethingWithGeocitiesToken(authorization.sessionToken);
       });

--- a/lib/torii/services/torii.js
+++ b/lib/torii/services/torii.js
@@ -31,7 +31,8 @@ function proxyToProvider(methodName, requireMethod){
  * Linked In via Oauth2 and authorization codes by doing
  * the following:
  *
- *     Torii.open('linked-in-oauth2').then(function(authData){
+ *     var options = {foo: 'bar'};
+ *     Torii.open('linked-in-oauth2', options).then(function(authData){
  *       console.log(authData.authorizationCode);
  *     });
  *
@@ -49,7 +50,8 @@ export default Ember.Service.extend({
    * namespace.
    *
    * @method open
-   * @param {String} providerName The provider to open
+   * @param {String} providerName The provider to call `open` on
+   * @param {Object} [options] options to pass to the provider's `open` method
    * @return {Ember.RSVP.Promise} Promise resolving to an authentication object
    */
   open:  proxyToProvider('open', true),
@@ -59,7 +61,8 @@ export default Ember.Service.extend({
    * already been opened.
    *
    * @method fetch
-   * @param {String} providerName The provider to open
+   * @param {String} providerName The provider to call `fetch` on
+   * @param {Object} [options] options to pass to the provider's `fetch` method
    * @return {Ember.RSVP.Promise} Promise resolving to an authentication object
    */
   fetch:  proxyToProvider('fetch'),
@@ -70,7 +73,8 @@ export default Ember.Service.extend({
    * and may be better handled by torii's session management instead.
    *
    * @method close
-   * @param {String} providerName The provider to open
+   * @param {String} providerName The provider to call `close` on
+   * @param {Object} [options] options to pass to the provider's `close` method
    * @return {Ember.RSVP.Promise} Promise resolving when the provider is closed
    */
   close:  proxyToProvider('close')


### PR DESCRIPTION
Adds documentation explaining that `options` passed to `this.get('torii').open(providerName, options)` will be passed to the `open` method of  `<providerName>`.

fixes #88 
