### PR TITLE
grunt-contrib-testem has been renamed to grunt-testem-mincer

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-connect": "~0.7.1",
     "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-testem": "~0.5.14",
+    "grunt-testem-mincer": "~0.5.18",
     "grunt-contrib-uglify": "~0.6.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-yuidoc": "~0.5.0",


### PR DESCRIPTION
`grunt-contrib-testem` has been renamed to `grunt-testem-mincer` https://github.com/inossidabile/grunt-testem-mincer/commit/10cb9d1589a6b237fb62e370140a6bc98603af9b. The original package name is no longer available on npm which prevents a fresh `npm install` from working.