### PR TITLE
Add Response params to the authorize object for Oauth2

### DIFF
--- a/lib/torii/providers/oauth2-code.js
+++ b/lib/torii/providers/oauth2-code.js
@@ -134,42 +134,44 @@ var Oauth2 = Provider.extend({
    * If there was an error or the user either canceled the authorization or
    * closed the popup window, the promise rejects.
    */
-  open: function(options){
-    var name        = this.get('name'),
-        url         = this.buildUrl(),
-        redirectUri = this.get('redirectUri'),
-        responseParams = this.get('responseParams'),
-        responseType = this.get('responseType'),
-        state = this.get('state'),
-        shouldCheckState = responseParams.indexOf('state') !== -1;
+   open: function(options){
+      var name        = this.get('name'),
+          url         = this.buildUrl(),
+          redirectUri = this.get('redirectUri'),
+          responseParams = this.get('responseParams'),
+          responseType = this.get('responseType'),
+          state = this.get('state'),
+          shouldCheckState = responseParams.indexOf('state') !== -1;
 
-    return this.get('popup').open(url, responseParams, options).then(function(authData){
-      var missingResponseParams = [];
+      return this.get('popup').open(url, responseParams, options).then(function(authData){
+        var missingResponseParams = [],
+        authObj = {
+          authorizationCode: authData[responseType],
+          provider: name,
+          redirectUri: redirectUri
+        };
 
-      responseParams.forEach(function(param){
-        if (authData[param] === undefined) {
-          missingResponseParams.push(param);
+        responseParams.forEach(function(param){
+          if (authData[param] === undefined) {
+            missingResponseParams.push(param);
+          }else{
+            authObj[param] = authData[param];
+          }
+        });
+
+        if (missingResponseParams.length){
+          throw new Error("The response from the provider is missing " +
+                "these required response params: " + missingResponseParams.join(', '));
         }
+
+        if (shouldCheckState && authData.state !== state) {
+          throw new Error('The response from the provider has an incorrect ' +
+                          'session state param: should be "' + state + '", ' +
+                          'but is "' + authData.state + '"');
+        }
+        return authObj;
       });
-
-      if (missingResponseParams.length){
-        throw new Error("The response from the provider is missing " +
-              "these required response params: " + missingResponseParams.join(', '));
-      }
-
-      if (shouldCheckState && authData.state !== state) {
-        throw new Error('The response from the provider has an incorrect ' +
-                        'session state param: should be "' + state + '", ' +
-                        'but is "' + authData.state + '"');
-      }
-
-      return {
-        authorizationCode: authData[responseType],
-        provider: name,
-        redirectUri: redirectUri
-      };
-    });
-  }
-});
+    }
+  });
 
 export default Oauth2;

--- a/lib/torii/providers/oauth2-code.js
+++ b/lib/torii/providers/oauth2-code.js
@@ -154,7 +154,7 @@ var Oauth2 = Provider.extend({
         responseParams.forEach(function(param){
           if (authData[param] === undefined) {
             missingResponseParams.push(param);
-          }else{
+          }else if(param !== responseType){
             authObj[param] = authData[param];
           }
         });


### PR DESCRIPTION
Including `responseParams` to an oauth2 provider will return an error if those params are missing from a response (as it should). However those responses are not passed back along. Those responses are generally to either verify that the server response is valid, or for further use in requesting a token. 

This adds those requested params to the authorization object. 