### PR TITLE
Cleanup pending requests

### DIFF
--- a/addon/mixins/ui-service-mixin.js
+++ b/addon/mixins/ui-service-mixin.js
@@ -47,6 +47,14 @@ var ServicesMixin = Ember.Mixin.create({
       service.openRemote(url, pendingRequestKey, options);
       service.schedulePolling();
 
+      var onbeforeunload = window.onbeforeunload;
+      window.onbeforeunload = function() {
+        if (typeof onbeforeunload === 'function') {
+          onbeforeunload();
+        }
+        service.close();
+      };
+
       if (service.remote && !service.remote.closed) {
         service.remote.focus();
       } else {

--- a/tests/unit/services/popup-test.js
+++ b/tests/unit/services/popup-test.js
@@ -156,3 +156,25 @@ test("open rejects when window closes", function(assert){
 
   mockWindow.closed = true;
 });
+
+test("localStorage state is cleaned up when parent window closes", function(assert){
+  var mockWindow = buildMockWindow();
+  window.open = function(){
+    assert.ok(true, 'calls window.open');
+    return mockWindow;
+  };
+
+  Ember.run(function(){
+    popup.open('some-url', ['code']).then(function(){
+      assert.ok(false, 'resolved the open promise');
+    }, function(){
+      assert.ok(false, 'rejected the open promise');
+    });
+  });
+
+  window.onbeforeunload();
+
+  assert.notOk(localStorage.getItem(CURRENT_REQUEST_KEY), "adds the key to the current request item");
+
+});
+


### PR DESCRIPTION
Currently, Torii tracks in flight requests using a localStorage key. If the browser window is closed, that key remains behind. This results in Torii thinking there is an in flight request the next time it runs on that same domain. It then attempts to close the opened remote, which fails:

![image](https://cloud.githubusercontent.com/assets/707213/14478171/6b80d77e-00d0-11e6-8a24-329082d138d5.png)

The solution implemented here uses the browser's `onbeforeunload` hook to remove the pending request key from localStorage, ensuring a clean state for the next page load.

## Steps to reproduce:

1. Open a torii session that results in a popup or iframe opening.
2. Close the parent browser window without touching the remote (iframe/popup) window.
3. Navigate back to the page in a new window, and attempt to open another torii session.