### PR TITLE
Fix issue with refresh when oauth is in an iframe.

### DIFF
--- a/addon/redirect-handler.js
+++ b/addon/redirect-handler.js
@@ -27,6 +27,7 @@ var RedirectHandler = Ember.Object.extend({
           // NOTE : If a single provider has been configured to use the 'iframe'
           // service, this next line will still be called. It will just fail silently.
           windowObject.close();
+          reject('force refresh');
         }
       } else{
         reject('Not a torii popup');


### PR DESCRIPTION
Hi everyone.

I'm using `torii` and `ember-simple-auth` in a project and we recently switched to showing the oauth login in an iframe rather than a popup. One issue that we noticed in testing was that, if you hit refresh before loggin in, the page would hang.

I really don't understand the issue and I was hoping someone might be able to shed some light on it for me. I think(tm) the issue boils down to the promise returned by `run()` never resolving. This hangs the application after the user refreshes their browser.

My hack solution is to reject the promise if there is a `pendingRequestKey` (looking at it now, the `reject` statement should be outside of the `if(remoteServiceNaem..` block). This seems to work but I'm really not happy with magic code like this. 

If anyone has any insights I'd love to figure this out and implement a real solution.

Thanks!