### PR TITLE
Recursively find hostApp

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,20 @@
 module.exports = {
   name: 'torii',
   included: function(app) {
-    var toriiConfig = this.app.project.config(app.env)['torii'];
+    var hostApp = this._findApp(app);
+    var toriiConfig = hostApp.project.config(app.env)['torii'];
     if (!toriiConfig) {
       console.warn('Torii is installed but not configured in config/environment.js!');
     }
+
     this._super.included(app);
+  },
+
+  _findApp: function(hostApp) {
+    var app = this.app || hostApp;
+    while (app.app) {
+      app = app.app;
+    }
+    return app;
   }
 };


### PR DESCRIPTION
Makes torii safer to use in a nested addon or in an in-repo-addon.

Different incantations of the `_super.included` hook (see below) in an in-repo-addon
change the context that torii's `included` gets called with.

See also https://github.com/ember-cli/ember-cli/issues/5747#issuecomment-206357164
and https://github.com/machty/ember-concurrency/pull/46

  * `this._super.included(app)` vs `this._super.included.apply(this, arguments)`
    in another addon will change whether `this.app` exists in torii's `included` hook