### PR TITLE
Implement condition which checks if FB was already initialized and assigned to the window object

### DIFF
--- a/addon/providers/facebook-connect.js
+++ b/addon/providers/facebook-connect.js
@@ -18,6 +18,7 @@ function fbLoad(settings){
   var locale = settings.locale;
   delete settings.locale;
   fbPromise = new Ember.RSVP.Promise(function(resolve, reject){
+    if (window.FB) { return resolve(); }
     window.fbAsyncInit = function(){
       FB.init(settings);
       Ember.run(null, resolve);


### PR DESCRIPTION
If FB was already initialized and assigned to the window object by another service, torii stops authentication but will not throw any error or warning. 

The added condition prevents from this error.

For further information please see [issue #296](https://github.com/Vestorly/torii/issues/296).
