### PR TITLE
Genericize torii session name.

### DIFF
--- a/test-support/helpers/torii.js
+++ b/test-support/helpers/torii.js
@@ -1,8 +1,16 @@
-export function stubValidSession(application,sessionData) {
-  var session = application.__container__.lookup('service:session');
-  var sm = session.get('stateMachine');
-  Ember.run(function() {
+import config from '../../config/environment';
+
+const {
+  torii: { sessionServiceName }
+} = config;
+
+export function stubValidSession(application, sessionData) {
+  let session = application.__container__.lookup(`service:${sessionServiceName}`);
+
+  let sm = session.get('stateMachine');
+  Ember.run(() => {
     sm.send('startOpen');
     sm.send('finishOpen', sessionData);
   });
 }
+


### PR DESCRIPTION
This PR would make the torii session helper get the `sessionServiceName` that the user has defined.

Fixes the issue: [https://github.com/Vestorly/torii/issues/307](https://github.com/Vestorly/torii/issues/307)
