### PR TITLE
Feature/steam

### DIFF
--- a/addon/providers/steam-oauth2-bearer.js
+++ b/addon/providers/steam-oauth2-bearer.js
@@ -1,0 +1,27 @@
+/**
+ * This class implements authentication against google
+ * using the client-side OAuth2 authorization flow in a popup window.
+ */
+
+import Oauth2Bearer from 'torii/providers/oauth2-bearer';
+import {configurable} from 'torii/configuration';
+
+var SteamOauth2Bearer = Oauth2Bearer.extend({
+
+  name:    'steam-oauth2-bearer',
+  baseUrl: 'http://localhost:3000/auth/steam',
+
+  // additional params that this provider requires
+  optionalUrlParams: ['scope', 'request_visible_actions'],
+
+  requestVisibleActions: configurable('requestVisibleActions', ''),
+
+  responseParams: ['access_token'],
+
+  scope: configurable('scope', 'email'),
+
+  redirectUri: configurable('redirectUri',
+                            'http://localhost:4200/oauth2callback')
+});
+
+export default SteamOauth2Bearer;

--- a/addon/providers/steam-oauth2.js
+++ b/addon/providers/steam-oauth2.js
@@ -1,0 +1,21 @@
+import {configurable} from 'torii/configuration';
+import Oauth2 from 'torii/providers/oauth2-code';
+
+export default Oauth2.extend({
+  name:    'steam-oauth2',
+  baseUrl: 'http://localhost:3000/auth/steam',
+
+  // Additional url params that this provider requires
+  requiredUrlParams: ['display'],
+
+  responseParams: ['code', 'state'],
+
+  scope:        configurable('scope', 'email'),
+
+  display: 'popup',
+  redirectUri: configurable('redirectUri', function(){
+    // A hack that allows redirectUri to be configurable
+    // but default to the superclass
+    return this._super();
+  })  
+});

--- a/tests/integration/providers/steam-oauth2-test.js
+++ b/tests/integration/providers/steam-oauth2-test.js
@@ -1,0 +1,55 @@
+var torii, app;
+
+import { configure } from 'torii/configuration';
+import MockPopup from '../../helpers/mock-popup';
+import startApp from '../../helpers/start-app';
+import lookup from '../../helpers/lookup';
+import QUnit from 'qunit';
+
+const { module, test } = QUnit;
+
+var mockPopup = new MockPopup();
+
+var failPopup = new MockPopup({ state: 'invalid-state' });
+
+module('Steam - Integration', {
+  setup: function(){
+    app = startApp({loadInitializers: true});
+    app.register('torii-service:mock-popup', mockPopup, {instantiate: false});
+    app.register('torii-service:fail-popup', failPopup, {instantiate: false});
+    app.inject('torii-provider', 'popup', 'torii-service:mock-popup');
+
+    torii = lookup(app, "service:torii");
+    configure({
+      providers: {
+        'steam-oauth2': {
+          apiKey: 'dummy'
+        }
+      }
+    });
+  },
+
+  teardown: function(){
+    mockPopup.opened = false;
+    Ember.run(app, 'destroy');
+  }
+});
+
+test("Opens a popup to Steam", function(assert){
+  Ember.run(function(){
+    torii.open('steam-oauth2').finally(function(){
+      assert.ok(mockPopup.opened, "Popup service is opened");
+    });
+  });
+});
+
+test('Validates the state parameter in the response', function(assert){
+  app.inject('torii-provider', 'popup', 'torii-service:fail-popup');
+
+  Ember.run(function(){
+    torii.open('steam-oauth2').then(null, function(e){
+      assert.ok(/has an incorrect session state/.test(e.message),
+         'authentication fails due to invalid session state response');
+    });
+  });
+});


### PR DESCRIPTION
This is the start of a Steam Oauth2 branch. Currently, because of openID on Steam, need to redirect to either an openID server, or use passport. However passport and Ember-simple-auth have been known to play poorly together.

This is the start, please contribute if possible!