### PR TITLE
Google OAuth2 provider update

### DIFF
--- a/addon/bootstrap/torii.js
+++ b/addon/bootstrap/torii.js
@@ -1,6 +1,7 @@
 import LinkedInOauth2Provider from 'torii/providers/linked-in-oauth2';
 import GoogleOauth2Provider from 'torii/providers/google-oauth2';
 import GoogleOauth2BearerProvider from 'torii/providers/google-oauth2-bearer';
+import GoogleOauth2BearerV2Provider from 'torii/providers/google-oauth2-bearer-v2';
 import FacebookConnectProvider from 'torii/providers/facebook-connect';
 import FacebookOauth2Provider from 'torii/providers/facebook-oauth2';
 import ApplicationAdapter from 'torii/adapters/application';
@@ -23,6 +24,7 @@ export default function(application) {
   application.register('torii-provider:linked-in-oauth2', LinkedInOauth2Provider);
   application.register('torii-provider:google-oauth2', GoogleOauth2Provider);
   application.register('torii-provider:google-oauth2-bearer', GoogleOauth2BearerProvider);
+  application.register('torii-provider:google-oauth2-bearer-v2', GoogleOauth2BearerV2Provider);
   application.register('torii-provider:facebook-connect', FacebookConnectProvider);
   application.register('torii-provider:facebook-oauth2', FacebookOauth2Provider);
   application.register('torii-provider:twitter', TwitterProvider);

--- a/addon/providers/google-oauth2-bearer-v2.js
+++ b/addon/providers/google-oauth2-bearer-v2.js
@@ -97,12 +97,14 @@ var GoogleOauth2BearerV2 = OAuth2Code.extend({
               // the token is valid if the 'audience' is the same as the
               // 'client_id' (apiKey) provided to initiate authentication
               if (jsonResponse.audience === clientId) {
-                // authentication succeeded
-                resolve({
-                  authorizationToken: authData,
-                  provider: name,
-                  redirectUri: redirectUri
-                });
+                // authentication succeeded. Add name and redirectUri to the
+                // authentication data and resolve
+                resolve(Object.assign(authData,
+                  {
+                    provider: name,
+                    redirectUri: redirectUri
+                  }
+                ));
               } else if (jsonResponse.audience === undefined) {
                 // authentication failed because the response from the server
                 // is not as expected (no 'audience' field)
@@ -128,6 +130,13 @@ var GoogleOauth2BearerV2 = OAuth2Code.extend({
         return authenticationData;
       });
     });
+  },
+
+  fetch: function (authenticationData) {
+    // this is the most basic for ember-simple-auth to work with this provider,
+    // but the session could actually be checked and renewed here if the token
+    // is too old.
+    return authenticationData;
   }
 });
 

--- a/addon/providers/google-oauth2-bearer-v2.js
+++ b/addon/providers/google-oauth2-bearer-v2.js
@@ -1,0 +1,114 @@
+/**
+ * This class implements authentication against google's authentication server
+ * using v2, using the client-side OAuth2 authorization flow in a popup window.
+ */
+
+import OAuth2Code from 'torii/providers/oauth2-code';
+import {configurable} from 'torii/configuration';
+import Ember from 'ember';
+
+var GoogleOauth2BearerV2 = OAuth2Code.extend({
+
+  name:    'google-oauth2-bearer-v2',
+
+  baseUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+
+  tokenValidationUrl: 'https://www.googleapis.com/oauth2/v2/tokeninfo',
+
+  // additional params that this provider requires
+  optionalUrlParams: ['scope', 'request_visible_actions'],
+
+  scope: configurable('scope'),
+
+  requestVisibleActions: configurable('requestVisibleActions', ''),
+
+  responseType: 'token',
+
+  responseParams: ['access_token', 'token_type', 'expires_in'],
+
+  redirectUri: configurable('redirectUri'),
+
+  /**
+   * @method open
+   * @return {Promise<object>} If the authorization attempt is a success,
+   * the promise will resolve an object containing the following keys:
+   *   - authorizationToken: The `token` from the 3rd-party provider
+   *   - provider: The name of the provider (i.e., google-oauth2)
+   *   - redirectUri: The redirect uri (some server-side exchange flows require this)
+   * If there was an error or the user either canceled the authorization or
+   * closed the popup window, the promise rejects.
+   */
+  open: function(options){
+    var name        = this.get('name'),
+        url         = this.buildUrl(),
+        redirectUri = this.get('redirectUri'),
+        responseParams = this.get('responseParams'),
+        tokenValidationUrl = this.get('tokenValidationUrl'),
+        clientId = this.get('apiKey');
+
+    return this.get('popup').open(url, responseParams, options).then(function(authData){
+      var missingResponseParams = [];
+
+      responseParams.forEach(function(param){
+        if (authData[param] === undefined) {
+          missingResponseParams.push(param);
+        }
+      });
+
+      if (missingResponseParams.length){
+        throw new Error("The response from the provider is missing " +
+              "these required response params: " +
+              missingResponseParams.join(', '));
+      }
+
+      /* at this point 'authData' should look like:
+      {
+        access_token: '<some long acces token string>',
+        expires_in: '<time in s, was '3600' in jan 2017>',
+        token_type: 'Bearer'
+      }
+      */
+
+      // Validation of the token, for details, see
+      // https://developers.google.com/identity/protocols/OAuth2UserAgent#validatetoken
+
+      // Token validation request
+      Ember.$.ajax(
+        {
+          type: 'GET',
+          url: tokenValidationUrl,
+          data: {
+            'access_token': authData['access_token']
+          },
+          success: function (jsonResponse) {
+            /* the response is a JSON that looks like:
+            {
+              "audience":"8819981768.apps.googleusercontent.com",
+              "user_id":"123456789",
+              "scope":"profile email",
+              "expires_in":436
+            }
+            */
+            // the token is valid if the 'audience' is the same as the client ID
+            if (jsonResponse.audience === clientId) {
+              // authentication succeeded
+              return {
+                authorizationToken: authData,
+                provider: name,
+                redirectUri: redirectUri
+              };
+            } else {
+              throw new Error('Invalid access token.');
+            }
+          },
+          error: function (response) {
+            throw new Error('Connot reach the token validation server: ' +
+                             tokenValidationUrl);
+          }
+        }
+      );
+    });
+  }
+});
+
+export default GoogleOauth2BearerV2;

--- a/addon/providers/google-oauth2-bearer-v2.js
+++ b/addon/providers/google-oauth2-bearer-v2.js
@@ -39,6 +39,7 @@ var GoogleOauth2BearerV2 = OAuth2Code.extend({
    * closed the popup window, the promise rejects.
    */
   open: function(options){
+
     var name        = this.get('name'),
         url         = this.buildUrl(),
         redirectUri = this.get('redirectUri'),
@@ -119,6 +120,8 @@ var GoogleOauth2BearerV2 = OAuth2Code.extend({
             }
           }
         );
+      }).then( function (authenticationData) {
+        return authenticationData;
       });
     });
   }

--- a/addon/providers/google-oauth2-bearer-v2.js
+++ b/addon/providers/google-oauth2-bearer-v2.js
@@ -1,12 +1,14 @@
-/**
- * This class implements authentication against google's authentication server
- * using v2, using the client-side OAuth2 authorization flow in a popup window.
- */
-
 import OAuth2Code from 'torii/providers/oauth2-code';
 import {configurable} from 'torii/configuration';
 import Ember from 'ember';
 
+/**
+ * This class implements a provider allowing authentication against google's
+ * authentication server using v2 of google's OAuth2 authentication flow. The
+ * user is invited to authenticate in a popup window. Once a token is obtained,
+ * it is validated by a second HTTP request (to another url). Authentication is
+ * complte once this validation step has succeeded, and the token is returned.
+ */
 var GoogleOauth2BearerV2 = OAuth2Code.extend({
 
   name:    'google-oauth2-bearer-v2',
@@ -15,9 +17,11 @@ var GoogleOauth2BearerV2 = OAuth2Code.extend({
 
   tokenValidationUrl: 'https://www.googleapis.com/oauth2/v2/tokeninfo',
 
-  // additional params that this provider requires
+  // additional parameters that this provider requires
   optionalUrlParams: ['scope', 'request_visible_actions'],
 
+  // a scope MUST be given (no default value because there are so many possible
+  // at Google)
   scope: configurable('scope'),
 
   requestVisibleActions: configurable('requestVisibleActions', ''),

--- a/package.json
+++ b/package.json
@@ -84,6 +84,10 @@
     {
       "name": "Vestorly",
       "email": "hello@vestorly.com"
+    },
+    {
+      "name": "J.-F. Schaff",
+      "email": "jfschaff@gmail.com"
     }
   ],
   "maintainers": [

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  authData: {},
+
+  authDataStr: Ember.computed('authData', function () {
+    return JSON.stringify(this.get('authData'), null, 2);
+  })
+});

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -3,10 +3,11 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   actions: {
     signIn(providerName) {
-      this.get('torii').open(providerName).then(authData => {
-        console.log('authData',authData);
-      }).catch(err => {
-        console.log('err',err);
+      this.get('torii').open(providerName).then((authData) => {
+        this.controller.set('authData', authData);
+        console.log('authData', authData);
+      }).catch((err) => {
+        console.log('err', err);
       });
     }
   }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,50 @@
-<h1>torii on ember-cli</h1>
+<h1>Torii on EmberCLI!</h1>
+
+<h2>First configure your provider</h2>
+
+<p>To test a provider, first configure it in your app's <code>'config/environment.js'</code> file:
+<ul>
+  <li>use your own client ID or API key</li>
+  <li>choose a scope</li>
+  <li>set other provider-dependent parameters...</li>
+</ul>
+</p>
+
+
+<h2>Example: OAuth2 with Google</h2>
+
+<p>For instance, for the Google OAuth2 provider <code>'google-oauth2-bearer-v2'</code>, adapt the following code sample:
+<pre>
+// config/environment.js
+
+module.exports = function(environment) {
+  var ENV = {
+    ...
+    torii: {
+      providers: {
+        'google-oauth2-bearer-v2' : {
+          apiKey: '&lt;copy your Google client ID here&gt;',
+          redirectUri: '&lt;a URI that is configured in your Google developer console&gt;', // e.g. 'http://localhost:4200'
+          scope: '&lt;one of the many possible scopes, depending on what you want to do&gt;'
+        }
+      }
+    }
+  };
+</pre>
+For a list of all possible scopes, see <a target="_blank" href="https://developers.google.com/identity/protocols/googlescopes">https://developers.google.com/identity/protocols/googlescopes</a>.
+</p>
+
+
+<h1>Test "Sign in" buttons</h1>
 
 <button {{action 'signIn' 'github-oauth2'}}>Sign in to github</button>
+
+<button {{action 'signIn' 'google-oauth2-bearer-v2'}}>Sign in to Google</button>
+
+
+<h2>Result of the authentication flow</h2>
+
+<pre>
+authData =
+{{authDataStr}}
+</pre>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -21,6 +21,15 @@ module.exports = function(environment) {
       providers: {
         'github-oauth2': {
           apiKey: '954836589bc32e767422'
+        },
+        'google-oauth2-bearer-v2' : {
+          // put your Google client ID here
+          apiKey: '<your Google client ID here>',
+          // use the same URI here as one configured in your Google developer console
+          redirectUri: 'http://localhost:4200',
+          // for a list of all possible scopes, see
+          // https://developers.google.com/identity/protocols/googlescopes
+          scope: 'https://www.googleapis.com/auth/gmail.readonly'
         }
       }
     }


### PR DESCRIPTION
Hi, this fixes what I mentioned in issue #331.

I implemented a new provider, named 'google-oauth2-bearer-v2', which uses Google's most recent authentication URL. It also performs an extra step: once a token is received, it is first validated by a second request to another URL (see [that link](https://developers.google.com/identity/protocols/OAuth2UserAgent#tokeninfo-validation) for more details).

I tested this provider with Ember Simple Auth, and fixed a couple of initial issues. I also included an example use of this provider in the example application, and instructions on how to set the provider.