### PR TITLE
Handle frozen url params properties

### DIFF
--- a/addon/lib/query-string.js
+++ b/addon/lib/query-string.js
@@ -35,8 +35,8 @@ function getOptionalParamValue(obj, paramName){
 export default Ember.Object.extend({
   init: function() {
     this.obj               = this.provider;
-    this.urlParams         = Ember.A(this.requiredParams).uniq();
-    this.optionalUrlParams = Ember.A(this.optionalParams || []).uniq();
+    this.urlParams         = Ember.A(this.requiredParams.slice()).uniq();
+    this.optionalUrlParams = Ember.A(this.optionalParams ? this.optionalParams.slice() : []).uniq();
 
     this.optionalUrlParams.forEach(function(param){
       if (this.urlParams.indexOf(param) > -1) {

--- a/tests/unit/lib/query-string-test.js
+++ b/tests/unit/lib/query-string-test.js
@@ -3,6 +3,7 @@ import QueryString from 'torii/lib/query-string';
 import QUnit from 'qunit';
 
 let { module, test } = QUnit;
+let { freeze } = Object;
 
 var obj,
     clientId = 'abcdef',
@@ -31,6 +32,12 @@ test('looks up properties by camelized name', function(assert){
 
   assert.equal(qs.toString(), 'client_id='+clientId,
         'sets client_id from clientId property');
+});
+
+test('does not fail when requiredParams or optionalParams are frozen', function(assert){
+  assert.expect(0);
+
+  QueryString.create({provider: obj, requiredParams: freeze(['client_id']), optionalParams: freeze(['optional_property'])});
 });
 
 test('joins properties with "&"', function(assert){


### PR DESCRIPTION
Ember will freeze concatenated properties so they cannot be mutated once applied. While that makes sense, torii's `QueryString` does not currently work when passed frozen `requiredParams` or `optionalParams` as frozen arrays cannot be passed to `Ember.A` (see discussion here: emberjs/ember.js#15020). This fixes that by simply cloning those properties before passing them to `Ember.A`.

Closes #337 