### PR TITLE
fix Circle CI build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 0.10.28
+    version: "v4"
 dependencies:
   pre:
     - npm install -g bower

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,9 +8,9 @@ module.exports = {
       }
     },
     {
-      name: 'Ember 1.13.16',
+      name: 'Ember 1.13.13',
       dependencies: {
-        'ember': '1.13.16'
+        'ember': '1.13.13'
       }
     },
     {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -41,7 +41,8 @@ module.exports = {
       },
       resolutions: {
         'ember': 'beta'
-      },
+      }
+    },
     {
       name: 'Ember Release',
       dependencies: {
@@ -50,7 +51,6 @@ module.exports = {
       resolutions: {
         'ember': 'release'
       }
-    }
     }
   ]
 };


### PR DESCRIPTION
The ember-try config is actually broken currently which breaks the CircleCLI build…

This also updates the node version used on Circle to 4 from 0.10.