### PR TITLE
Replace Ember.K with a function that returns this

### DIFF
--- a/addon/services/torii-session.js
+++ b/addon/services/torii-session.js
@@ -29,7 +29,9 @@ export default Ember.Service.extend(Ember._ProxyMixin, {
   }),
 
   // Make these properties one-way.
-  setUnknownProperty: Ember.K,
+  setUnknownProperty: function() {
+    return this;
+  },
 
   open: function(provider, options){
     var owner     = getOwner(this),

--- a/tests/unit/redirect-handler-test.js
+++ b/tests/unit/redirect-handler-test.js
@@ -17,7 +17,9 @@ function buildMockWindow(windowName, url){
       getItem: function() {},
       removeItem: function() {}
     },
-    close: Ember.K
+    close: function() {
+      return this;
+    }
   };
 }
 

--- a/tests/unit/services/popup-test.js
+++ b/tests/unit/services/popup-test.js
@@ -12,8 +12,12 @@ var buildMockWindow = function(windowName){
   windowName = windowName || "";
   return {
     name: windowName,
-    focus: Ember.K,
-    close: Ember.K
+    focus: function() {
+      return this;
+    },
+    close: function() {
+      return this;
+    }
   };
 };
 


### PR DESCRIPTION
`Ember.K` is deprecated (http://emberjs.com/deprecations/v2.x/#toc_code-ember-k-code).

I've replaced all instances of `Ember.K` with a function that returns `this`. It seems like an empty function would do the trick too, but returning `this` gives the exact same behavior as before.