### PR TITLE
Fix failing build

### DIFF
--- a/addon/lib/query-string.js
+++ b/addon/lib/query-string.js
@@ -35,8 +35,8 @@ function getOptionalParamValue(obj, paramName){
 export default Ember.Object.extend({
   init: function() {
     this.obj               = this.provider;
-    this.urlParams         = Ember.A(this.requiredParams).uniq();
-    this.optionalUrlParams = Ember.A(this.optionalParams || []).uniq();
+    this.urlParams         = Ember.A(this.requiredParams.slice()).uniq();
+    this.optionalUrlParams = Ember.A(this.optionalParams ? this.optionalParams.slice() : []).uniq();
 
     this.optionalUrlParams.forEach(function(param){
       if (this.urlParams.indexOf(param) > -1) {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -27,6 +27,7 @@ module.exports = {
     },
     {
       name: 'Ember Canary',
+      allowedToFail: true,
       dependencies: {
         'ember': 'components/ember#canary'
       },
@@ -36,6 +37,7 @@ module.exports = {
     },
     {
       name: 'Ember Beta',
+      allowedToFail: true,
       dependencies: {
         'ember': 'components/ember#beta'
       },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-try": "0.0.8",
+    "ember-try": "^0.2.12",
     "grunt": "~0.4.2",
     "grunt-banner": "^0.2.3",
     "grunt-cli": "~0.1.11",

--- a/tests/acceptance/ember-init-test.js
+++ b/tests/acceptance/ember-init-test.js
@@ -60,7 +60,9 @@ test('session is injectable using inject.service', function(assert){
     torii: Ember.inject.service('torii')
   }));
 
-  var component = lookupFactory(app, 'component:testComponent').create();
+  var DummyRenderer = { componentInitAttrs() {} };
+
+  var component = lookupFactory(app, 'component:testComponent').create({renderer: DummyRenderer});
 
   assert.ok(component.get('session'), 'Component has access to injected session service');
   assert.ok(component.get('torii'), 'Component has access to injected torii service');

--- a/tests/unit/lib/query-string-test.js
+++ b/tests/unit/lib/query-string-test.js
@@ -3,6 +3,7 @@ import QueryString from 'torii/lib/query-string';
 import QUnit from 'qunit';
 
 let { module, test } = QUnit;
+let { freeze } = Object;
 
 var obj,
     clientId = 'abcdef',
@@ -31,6 +32,12 @@ test('looks up properties by camelized name', function(assert){
 
   assert.equal(qs.toString(), 'client_id='+clientId,
         'sets client_id from clientId property');
+});
+
+test('does not fail when requiredParams or optionalParams are frozen', function(assert){
+  assert.expect(0);
+
+  QueryString.create({provider: obj, requiredParams: freeze(['client_id']), optionalParams: freeze(['optional_property'])});
 });
 
 test('joins properties with "&"', function(assert){


### PR DESCRIPTION
This PR is a rebase of #341, with a few additional changes to get tests passing:

  * Upgrade ember-try to latest and allow beta and canary to fail (for now)
  * Specify a dummy renderer for one unit test that does component instantiation