### PR TITLE
cherry-pick fix test: use InertRenderer in test

### DIFF
--- a/tests/acceptance/ember-init-test.js
+++ b/tests/acceptance/ember-init-test.js
@@ -60,9 +60,8 @@ test('session is injectable using inject.service', function(assert){
     torii: Ember.inject.service('torii')
   }));
 
-  var DummyRenderer = { componentInitAttrs() {} };
-
-  var component = lookupFactory(app, 'component:testComponent').create({renderer: DummyRenderer});
+  var renderer = lookupFactory(app, 'renderer:-inert');
+  var component = lookupFactory(app, 'component:testComponent').create({ renderer: renderer });
 
   assert.ok(component.get('session'), 'Component has access to injected session service');
   assert.ok(component.get('torii'), 'Component has access to injected torii service');


### PR DESCRIPTION
Uses the InertRenderer in unit test that instantiates a component

Cherry-picks one of the commits from #326