### PR TITLE
Replace `Ember.K` usage with JavaScript syntax  (rebased)

### DIFF
--- a/addon/services/torii-session.js
+++ b/addon/services/torii-session.js
@@ -29,7 +29,7 @@ export default Ember.Service.extend(Ember._ProxyMixin, {
   }),
 
   // Make these properties one-way.
-  setUnknownProperty: Ember.K,
+  setUnknownProperty() {},
 
   open: function(provider, options){
     var owner     = getOwner(this),

--- a/tests/unit/redirect-handler-test.js
+++ b/tests/unit/redirect-handler-test.js
@@ -17,7 +17,7 @@ function buildMockWindow(windowName, url){
       getItem: function() {},
       removeItem: function() {}
     },
-    close: Ember.K
+    close: function() {}
   };
 }
 

--- a/tests/unit/services/popup-test.js
+++ b/tests/unit/services/popup-test.js
@@ -12,8 +12,8 @@ var buildMockWindow = function(windowName){
   windowName = windowName || "";
   return {
     name: windowName,
-    focus: Ember.K,
-    close: Ember.K
+    focus() {},
+    close() {}
   };
 };
 


### PR DESCRIPTION
rebased version of #322 (to fix unrelated failures due to node version). Thanks @locks, @drewchandler, @kybishop and @kturney who all opened PRs to fix the issue. ❤️ 