### PR TITLE
Remove mentions of bower installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ authorization is destroyed.
 A provider in Torii is anything a user can authenticate against. This could be an
 OAuth 2.0 endpoint, your own login mechanism, or an SDK like Facebook Connect.
 Authenticating against a **provider** is done via the `torii` property, which is injected
-on to routes:
+into routes:
 
 ```hbs
 {{! app/templates/post.hbs }}
@@ -236,40 +236,19 @@ The session will automatically be populated if the user is logged in, otherwise 
 
 Using Torii currently requires an AMD-compatible module loader. [Ember-CLI](http://www.ember-cli.com/) provide this out of the box.
 
-### Using Torii as an ember-addon
+### Installing Torii
 
-Torii is configured to be compatible with the ember-cli
-[ember-addon](http://reefpoints.dockyard.com/2014/06/24/introducing_ember_cli_addons.html)
-functionality, as of ember-cli version 0.0.37.
+Torii is an ember addon and can be installed via:
 
-If you are using ember-cli at version 0.0.37 or later, you can simply install the torii npm module:
-
-`npm install torii --save-dev`
-
-The ember-addon hooks will include torii into your app and add its
-initializers.
+```
+ember install torii
+```
 
 ### Using Torii via bower
 
-Torii is also published as a bower package (as named amd modules).
-Install via bower:
-
-`bower install torii`
-
-Next, **add Torii to your build pipeline**. In Ember-App-Kit you do this
-in `app/index.html`. In Ember-CLI, you add the package to the `Brocfile.js`:
-
-```
-// Your path to torii may be different than the one below, depending on
-// your bower configuration.
-app.import('vendor/torii/dist/torii.amd.js');
-```
-
-**Add Torii's intialization code to your app**. Torii exports an amd module named `torii/load-initializers`, which will
-add the appropriate application initializers to do Torii's container registrations and injections.
-You will want to add `require('torii/load-initializers')['default']();` to your `app.js` file after you've defined your app
-and before you've created it.
-Here is an [example app.js](https://gist.github.com/bantic/b86787ed315c5ef98323).
+As of v0.8.0, Torii is no longer published to bower. For legacy uses, there is
+an AMD build of Torii published to bower at version 0.6.1. For modern usage of
+Torii, install it as an ember addon.
 
 ## Configuring a Torii provider
 
@@ -297,21 +276,6 @@ module.exports = function(environment) {
     }
   };
   return ENV;
-};
-```
-
-For a non-ember-cli application, you can set the same values on `ENV`:
-
-```JavaScript
-// In Ember-App-Kit you will set this in app/index.html
-window.ENV = window.ENV || {};
-window.ENV['torii'] = {
-  providers: {
-    'facebook-connect': {
-      appId: 'xxxxx-some-app-id',
-      scope: 'email,user_birthday'
-    }
-  }
 };
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -1,55 +1,7 @@
 {
   "name": "torii",
-  "version": "0.8.2",
-  "description": "A set of clean abstractions for authentication in Ember.js",
-  "authors": [
-    {
-      "name": "Matt Beale",
-      "email": "matt.beale@madhatted.com"
-    },
-    {
-      "name": "Cory Forsyth",
-      "email": "cory.forsyth@gmail.com"
-    },
-    {
-      "name": "Vestorly",
-      "email": "hello@vestorly.com"
-    }
-  ],
-  "homepage": "http://vestorly.github.io/torii/",
-  "keywords": [
-    "authentication",
-    "ember",
-    "emberjs",
-    "authorization",
-    "oauth"
-  ],
-  "license": "https://github.com/Vestorly/torii/blob/master/LICENSE",
-  "main": [
-    "dist/torii.amd.js"
-  ],
-  "ignore": [
-    "bower_components",
-    "dist/commonjs",
-    "ember-addon",
-    "app-addon",
-    "vendor-addon",
-    "example",
-    "lib",
-    "tasks",
-    "test",
-    "vendor",
-    "Gruntfile.js",
-    "package.json",
-    "testem.json",
-    "yuidoc.json"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/Vestorly/torii.git"
-  },
   "dependencies": {
-    "ember": "1.13.7",
+    "ember": "1.12.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",


### PR DESCRIPTION
The last AMD build that was published to bower was v0.6.1.