### PR TITLE
Ember 2.13 - Fix deprecated usage of router.router

### DIFF
--- a/addon/router-dsl-ext.js
+++ b/addon/router-dsl-ext.js
@@ -12,6 +12,7 @@ Router.reopen({
   _initRouterJs: function() {
     currentMap = [];
     this._super.apply(this, arguments);
-    this.router.authenticatedRoutes = currentMap;
+    let routerLib = this._routerMicrolib || this.router;
+    routerLib.authenticatedRoutes = currentMap;
   }
 });

--- a/app/instance-initializers/setup-routes.js
+++ b/app/instance-initializers/setup-routes.js
@@ -11,9 +11,11 @@ export default {
       return;
     }
 
-    var router = applicationInstance.get('router');
+    // backwards compat for Ember < 2.0
+    var router = applicationInstance.get('router') || applicationInstance.lookup('router:main');
     var setupRoutes = function(){
-      var authenticatedRoutes = router.router.authenticatedRoutes;
+      var _router = router._routerMicrolib || router.router;
+      var authenticatedRoutes = _router.authenticatedRoutes;
       var hasAuthenticatedRoutes = !Ember.isEmpty(authenticatedRoutes);
       if (hasAuthenticatedRoutes) {
         bootstrapRouting(applicationInstance, authenticatedRoutes);


### PR DESCRIPTION
https://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib