### PR TITLE
lookup torii service instead of using get

### DIFF
--- a/addon/services/torii-session.js
+++ b/addon/services/torii-session.js
@@ -33,7 +33,7 @@ export default Ember.Service.extend(Ember._ProxyMixin, {
 
   open: function(provider, options){
     var owner     = getOwner(this),
-        torii     = this.get('torii'),
+        torii     = getOwner(this).lookup('service:torii'),
         sm        = this.get('stateMachine');
 
     return new Ember.RSVP.Promise(function(resolve){


### PR DESCRIPTION
This should fix issues folks are having with 2.13 and get the test suite passing again

Fixes https://github.com/Vestorly/torii/issues/353
Fixes https://github.com/Vestorly/torii/issues/349