### PR TITLE
Fix this.router deprecation

### DIFF
--- a/addon/router-dsl-ext.js
+++ b/addon/router-dsl-ext.js
@@ -12,6 +12,8 @@ Router.reopen({
   _initRouterJs: function() {
     currentMap = [];
     this._super.apply(this, arguments);
-    this.router.authenticatedRoutes = currentMap;
+   
+    let routerMicrolib = this._routerMicrolib || this.router;
+    routerMicrolib.authenticatedRoutes = currentMap;
   }
 });


### PR DESCRIPTION
Using `this.router` is deprecated and gives warnings starting from Ember 2.13 (See https://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib).

This change migrates to the new `_routerMicrolib` while staying backwards compatible.