### PR TITLE
Isolate compatibility code to `/compat`

### DIFF
--- a/addon/compat/get-router-instance.js
+++ b/addon/compat/get-router-instance.js
@@ -1,0 +1,4 @@
+export default function getRouterInstance(appInstance) {
+  // backwards compat for Ember < 2.0
+  return appInstance.get('router') || appInstance.lookup('router:main');
+}

--- a/addon/compat/get-router-lib.js
+++ b/addon/compat/get-router-lib.js
@@ -1,0 +1,8 @@
+export default function getRouterLib(router) {
+  /**
+   * `router.router` deprecated in 2.13 until 2.16
+   * see https://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib
+   */
+  return router._routerMicrolib || router.router;
+}
+

--- a/addon/router-dsl-ext.js
+++ b/addon/router-dsl-ext.js
@@ -1,3 +1,5 @@
+import getRouterLib from 'torii/compat/get-router-lib';
+
 var Router = Ember.Router;
 var proto = Ember.RouterDSL.prototype;
 
@@ -12,7 +14,7 @@ Router.reopen({
   _initRouterJs: function() {
     currentMap = [];
     this._super.apply(this, arguments);
-    let routerLib = this._routerMicrolib || this.router;
+    let routerLib = getRouterLib(this);
     routerLib.authenticatedRoutes = currentMap;
   }
 });

--- a/app/instance-initializers/setup-routes.js
+++ b/app/instance-initializers/setup-routes.js
@@ -1,5 +1,7 @@
 import bootstrapRouting from 'torii/bootstrap/routing';
 import { getConfiguration } from 'torii/configuration';
+import getRouterInstance from 'torii/compat/get-router-instance';
+import getRouterLib from 'torii/compat/get-router-lib';
 import "torii/router-dsl-ext";
 
 export default {
@@ -11,11 +13,10 @@ export default {
       return;
     }
 
-    // backwards compat for Ember < 2.0
-    var router = applicationInstance.get('router') || applicationInstance.lookup('router:main');
+    let router = getRouterInstance(applicationInstance);
     var setupRoutes = function(){
-      var _router = router._routerMicrolib || router.router;
-      var authenticatedRoutes = _router.authenticatedRoutes;
+      let routerLib = getRouterLib(router);
+      var authenticatedRoutes = routerLib.authenticatedRoutes;
       var hasAuthenticatedRoutes = !Ember.isEmpty(authenticatedRoutes);
       if (hasAuthenticatedRoutes) {
         bootstrapRouting(applicationInstance, authenticatedRoutes);


### PR DESCRIPTION
This consolidates the compatibility fixes from #354 to `compat/` for
easier extraction in the future.