### PR TITLE
Fix redirectUri regression and add disableRedirectInitializer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,10 @@ By default Torii sets the `redirectUri` to
 `<currentURL>/torii/redirect.html`. If you wish to use the deprecated behavior
 then you will also have to manually configure the `redirectUri` to be `/`.
 
+If you are no longer relying on the deprecated behaviour and wish for it to no
+longer be executed you can manually disable it by setting
+`disableRedirectInitializer` to false in your `config.environment.js`.
+
 ## Providers in Torii
 
 Torii is built with several providers for common cases. If you intend to

--- a/addon/redirect-handler.js
+++ b/addon/redirect-handler.js
@@ -9,6 +9,13 @@
 import { CURRENT_REQUEST_KEY, WARNING_KEY } from "./mixins/ui-service-mixin";
 import configuration from 'torii/configuration';
 
+export class ToriiRedirectError extends Ember.Error {
+  constructor() {
+    super(...arguments);
+    this.name = 'ToriiRedirectError';
+  }
+}
+
 var RedirectHandler = Ember.Object.extend({
 
   run: function(){
@@ -28,8 +35,8 @@ var RedirectHandler = Ember.Object.extend({
           // service, this next line will still be called. It will just fail silently.
           windowObject.close();
         }
-      } else{
-        reject('Not a torii popup');
+      } else {
+        reject(new ToriiRedirectError('Not a torii popup'));
       }
     });
   }

--- a/app/initializers/initialize-torii-callback.js
+++ b/app/initializers/initialize-torii-callback.js
@@ -1,3 +1,4 @@
+import configuration from 'torii/configuration';
 import RedirectHandler from 'torii/redirect-handler';
 
 export default {
@@ -6,6 +7,9 @@ export default {
   initialize: function(application) {
     if (arguments[1]) { // Ember < 2.1
       application = arguments[1];
+    }
+    if (configuration.disableRedirectInitializer) {
+      return;
     }
     application.deferReadiness();
     RedirectHandler.handle(window).catch(function(){


### PR DESCRIPTION
* Fixes a regression introduced by commit f0b214f ("Deprecate Redirect Handler, use public/redirect.html as redirect target", 2017-05-22).

* Adds a way to disable the deprecated behavior. This caused a bug where attempting to refresh a Torii enabled app would cause the second instance to freeze because it notices the localStorage key and attempts to close the main window and then crashes. A second refresh will work because the localStorage key was removed before the crash. And a third refresh would be back in the same boat. The patterns continues on. Since we have a new `redirect.html` instead this behavior can be switched off via a configuration flag until the deprecated code is removed in a future release.