### PR TITLE
Make redirectUri configurable again

### DIFF
--- a/addon/providers/oauth2-code.js
+++ b/addon/providers/oauth2-code.js
@@ -105,7 +105,7 @@ var Oauth2 = Provider.extend({
   */
   responseParams: requiredProperty(),
 
-  redirectUri: computed(function defaultRedirectUri(){
+  redirectUri: configurable('redirectUri', function (){
     return `${currentUrl()}torii/redirect.html`;
   }),
 


### PR DESCRIPTION
This is a regression introduced by commit f0b214f ("Deprecate Redirect
Handler, use public/redirect.html as redirect target", 2017-05-22).

Supersedes part of #370

cc @sukima