### PR TITLE
URI-decode the OAuth2 authorization code

### DIFF
--- a/addon/providers/oauth2-code.js
+++ b/addon/providers/oauth2-code.js
@@ -168,7 +168,7 @@ var Oauth2 = Provider.extend({
       }
 
       return {
-        authorizationCode: authData[responseType],
+        authorizationCode: decodeURIComponent(authData[responseType]),
         provider: name,
         redirectUri: redirectUri
       };

--- a/tests/unit/providers/oauth2-code-test.js
+++ b/tests/unit/providers/oauth2-code-test.js
@@ -175,3 +175,35 @@ test('can override state property', function(assert){
   assert.equal(state, 'insecure-fixed-state',
         'specified state property is set');
 });
+
+test('URI-decodes the authorization code', function(assert){
+  assert.expect(1);
+
+  configure({
+    providers: {
+      'mock-oauth2-token': {
+        apiKey: 'dummyKey',
+        scope: 'someScope',
+        state: 'test-state'
+      }
+    }
+  });
+
+  var mockPopup = {
+    open: function(/*url, responseParams*/){
+      return Ember.RSVP.resolve({
+        'token_id': encodeURIComponent('test=='),
+        'authorization_code': 'pief',
+        'state': 'test-state'
+      });
+    }
+  };
+
+  tokenProvider.set('popup', mockPopup);
+
+  Ember.run(function(){
+    tokenProvider.open().then(function(res){
+      assert.equal(res.authorizationCode, 'test==', 'authorizationCode decoded');
+    });
+  });
+});


### PR DESCRIPTION
#### Why is this needed?

Some providers (ahem, salesforce) return authorization codes that need to be URI-decoded (salesforce ones tend to have a '==' at the end). Plus it's probably a good idea to `decodeURIComponent` strings that come from a URL anyway.

Closes #323