### PR TITLE
Add DOCTYPE and character set declaration to redirect.html

### DIFF
--- a/public/redirect.html
+++ b/public/redirect.html
@@ -1,5 +1,7 @@
+<!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>Torii OAuth Redirect</title>
     <script>
       var CURRENT_REQUEST_KEY = '__torii_request';


### PR DESCRIPTION
While totally not necessary for this behavior to work, adding a DOCTYPE and a `<meta charset>` tag is somewhat of a best practice. Happy to split this into two commits if that makes this easier. :)