### PR TITLE
Don't warn on empty config when included by an addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
   included: function(app) {
     var hostApp = this._findApp(app);
     var toriiConfig = hostApp.project.config(app.env)['torii'];
-    if (!toriiConfig) {
+    if (!toriiConfig && hostApp === app) {
       console.warn('Torii is installed but not configured in config/environment.js!');
     }
 


### PR DESCRIPTION
I'm making addons that depend on torii. They handle configuring torii for you. It would be helpful to make this warning go away for that scenario.