### PR TITLE
use new modules api

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,13 +4,17 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module'
   },
-  extends: 'eslint:recommended',
+  extends: [
+    'eslint:recommended',
+    'plugin:ember/recommended'
+  ],
   env: {
     browser: true
   },
   rules: {
+    'ember/no-global-jquery': 0, // this rule is broken
+    'ember/avoid-leaking-state-in-ember-objects': 0
   },
   globals: {
-    "Ember": false
   }
 };

--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -1,21 +1,23 @@
-var ApplicationAdapter = Ember.Object.extend({
+import { Promise as EmberPromise } from 'rsvp';
+import EmberObject from '@ember/object';
+var ApplicationAdapter = EmberObject.extend({
 
   open: function(){
-    return new Ember.RSVP.Promise(function(){
+    return new EmberPromise(function(){
       throw new Error(
         'The Torii adapter must implement `open` for a session to be opened');
     });
   },
 
   fetch: function(){
-    return new Ember.RSVP.Promise(function(){
+    return new EmberPromise(function(){
       throw new Error(
         'The Torii adapter must implement `fetch` for a session to be fetched');
     });
   },
 
   close: function(){
-    return new Ember.RSVP.Promise(function(){
+    return new EmberPromise(function(){
       throw new Error(
         'The Torii adapter must implement `close` for a session to be closed');
     });

--- a/addon/components/torii-iframe-placeholder.js
+++ b/addon/components/torii-iframe-placeholder.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['torii-iframe-placeholder']
 });

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -1,10 +1,10 @@
-var get = Ember.get;
+import { get, computed } from '@ember/object';
 
 const NAMESPACE = 'providers';
 let configuration = {};
 
 function configurable(configKey, defaultValue){
-  return Ember.computed(function configurableComputed(){
+  return computed(function configurableComputed(){
     // Trigger super wrapping in Ember 2.1.
     // See: https://github.com/emberjs/ember.js/pull/12359
     this._super = this._super || (function(){ throw new Error('should always have _super'); })();

--- a/addon/lib/container-utils.js
+++ b/addon/lib/container-utils.js
@@ -1,3 +1,5 @@
+import { getOwner as EmberGetOwner } from '@ember/application';
+
 export function hasRegistration(application, name) {
   if (application && application.hasRegistration) {
     return application.hasRegistration(name);
@@ -38,8 +40,8 @@ export function lookup(applicationInstance, name) {
 }
 
 export function getOwner(instance) {
-  if (Ember.getOwner) {
-    return Ember.getOwner(instance);
+  if (EmberGetOwner) {
+    return EmberGetOwner(instance);
   } else {
     return instance.container;
   }

--- a/addon/lib/load-initializer.js
+++ b/addon/lib/load-initializer.js
@@ -1,6 +1,7 @@
-/* global Ember */
-export default function(initializer){
-  Ember.onLoad('Ember.Application', function(Application){
+import { onLoad } from '@ember/application';
+
+export default function(initializer) {
+  onLoad('Ember.Application', function(Application){
     Application.initializer(initializer);
   });
 }

--- a/addon/lib/load-instance-initializer.js
+++ b/addon/lib/load-instance-initializer.js
@@ -1,6 +1,7 @@
-/* global Ember */
-export default function(instanceInitializer){
-  Ember.onLoad('Ember.Application', function(Application){
+import { onLoad } from '@ember/application';
+
+export default function(instanceInitializer) {
+  onLoad('Ember.Application', function(Application){
     Application.instanceInitializer(instanceInitializer);
   });
 }

--- a/addon/lib/parse-query-string.js
+++ b/addon/lib/parse-query-string.js
@@ -1,4 +1,6 @@
-export default Ember.Object.extend({
+import EmberObject from '@ember/object';
+
+export default EmberObject.extend({
   init: function() {
     this.validKeys = this.keys;
   },

--- a/addon/lib/query-string.js
+++ b/addon/lib/query-string.js
@@ -1,5 +1,6 @@
-var camelize = Ember.String.camelize,
-    get      = Ember.get;
+import { A } from '@ember/array';
+import { camelize } from '@ember/string';
+import EmberObject, { get } from '@ember/object';
 
 function isValue(value){
   return (value || value === false);
@@ -32,11 +33,11 @@ function getOptionalParamValue(obj, paramName){
   return getParamValue(obj, paramName, true);
 }
 
-export default Ember.Object.extend({
+export default EmberObject.extend({
   init: function() {
     this.obj               = this.provider;
-    this.urlParams         = Ember.A(this.requiredParams.slice()).uniq();
-    this.optionalUrlParams = Ember.A(this.optionalParams ? this.optionalParams.slice() : []).uniq();
+    this.urlParams         = A(this.requiredParams.slice()).uniq();
+    this.optionalUrlParams = A(this.optionalParams ? this.optionalParams.slice() : []).uniq();
 
     this.optionalUrlParams.forEach(function(param){
       if (this.urlParams.indexOf(param) > -1) {
@@ -49,7 +50,7 @@ export default Ember.Object.extend({
     var urlParams         = this.urlParams,
         optionalUrlParams = this.optionalUrlParams,
         obj               = this.obj,
-        keyValuePairs     = Ember.A([]);
+        keyValuePairs     = A([]);
 
     urlParams.forEach(function(paramName){
       var paramValue = getParamValue(obj, paramName);

--- a/addon/lib/required-property.js
+++ b/addon/lib/required-property.js
@@ -1,5 +1,7 @@
+import { computed } from '@ember/object';
+
 function requiredProperty(){
-  return Ember.computed(function(key){
+  return computed(function(key){
     throw new Error("Definition of property "+key+" by a subclass is required.");
   });
 }

--- a/addon/mixins/ui-service-mixin.js
+++ b/addon/mixins/ui-service-mixin.js
@@ -19,8 +19,8 @@ function parseMessage(url, keys){
 
 var ServicesMixin = Mixin.create({
 
-  init: function(){
-    this._super.apply(this, arguments);
+  init(){
+    this._super(...arguments);
     this.remoteIdGenerator = this.remoteIdGenerator || UUIDGenerator;
   },
 

--- a/addon/mixins/ui-service-mixin.js
+++ b/addon/mixins/ui-service-mixin.js
@@ -1,3 +1,8 @@
+import $ from 'jquery';
+import { later, run, cancel } from '@ember/runloop';
+import { Promise as EmberPromise } from 'rsvp';
+import Mixin from '@ember/object/mixin';
+import { on } from '@ember/object/evented';
 import UUIDGenerator from 'torii/lib/uuid-generator';
 import PopupIdSerializer from 'torii/lib/popup-id-serializer';
 import ParseQueryString from 'torii/lib/parse-query-string';
@@ -6,15 +11,13 @@ export const CURRENT_REQUEST_KEY = '__torii_request';
 export const WARNING_KEY = '__torii_redirect_warning';
 import { getConfiguration } from 'torii/configuration';
 
-var on = Ember.on;
-
 function parseMessage(url, keys){
   var parser = ParseQueryString.create({url: url, keys: keys});
   var data = parser.parse();
   return data;
 }
 
-var ServicesMixin = Ember.Mixin.create({
+var ServicesMixin = Mixin.create({
 
   init: function(){
     this._super.apply(this, arguments);
@@ -36,7 +39,7 @@ var ServicesMixin = Ember.Mixin.create({
     var service   = this,
         lastRemote = this.remote;
 
-    return new Ember.RSVP.Promise(function(resolve, reject){
+    return new EmberPromise(function(resolve, reject){
       if (lastRemote) {
         service.close();
       }
@@ -85,19 +88,19 @@ var ServicesMixin = Ember.Mixin.create({
         }
         // If we don't receive a message before the timeout, we fail. Normally,
         // the message will be received and the window will close immediately.
-        service.timeout = Ember.run.later(service, function() {
+        service.timeout = later(service, function() {
           reject(new Error("remote was closed, authorization was denied, or an authentication message otherwise not received before the window closed."));
         }, 100);
       });
 
-      Ember.$(window).on('storage.torii', function(event){
+      $(window).on('storage.torii', function(event){
         var storageEvent = event.originalEvent;
 
         var remoteIdFromEvent = PopupIdSerializer.deserialize(storageEvent.key);
         if (remoteId === remoteIdFromEvent){
           var data = parseMessage(storageEvent.newValue, keys);
           localStorage.removeItem(storageEvent.key);
-          Ember.run(function() {
+          run(function() {
             resolve(data);
           });
         }
@@ -106,7 +109,7 @@ var ServicesMixin = Ember.Mixin.create({
       // didClose will reject this same promise, but it has already resolved.
       service.close();
 
-      Ember.$(window).off('storage.torii');
+      $(window).off('storage.torii');
     });
   },
 
@@ -124,7 +127,7 @@ var ServicesMixin = Ember.Mixin.create({
   },
 
   schedulePolling: function(){
-    this.polling = Ember.run.later(this, function(){
+    this.polling = later(this, function(){
       this.pollRemote();
       this.schedulePolling();
     }, 35);
@@ -132,12 +135,12 @@ var ServicesMixin = Ember.Mixin.create({
 
   // Clear the timeout, in case it hasn't fired.
   clearTimeout: function(){
-    Ember.run.cancel(this.timeout);
+    cancel(this.timeout);
     this.timeout = null;
   },
 
   stopPolling: on('didClose', function(){
-    Ember.run.cancel(this.polling);
+    cancel(this.polling);
   })
 });
 

--- a/addon/providers/azure-ad-oauth2.js
+++ b/addon/providers/azure-ad-oauth2.js
@@ -1,7 +1,6 @@
+import { computed } from '@ember/object';
 import Oauth2 from 'torii/providers/oauth2-code';
-import {configurable} from 'torii/configuration';
-
-var computed = Ember.computed;
+import { configurable } from 'torii/configuration';
 
 /**
  * This class implements authentication against AzureAD

--- a/addon/providers/base.js
+++ b/addon/providers/base.js
@@ -1,3 +1,4 @@
+import EmberObject, { computed } from '@ember/object';
 import requiredProperty from 'torii/lib/required-property';
 import { getOwner } from 'torii/lib/container-utils';
 import { configurable } from 'torii/configuration';
@@ -5,13 +6,11 @@ import configuration from 'torii/configuration';
 
 var DEFAULT_REMOTE_SERVICE_NAME = 'popup';
 
-var computed = Ember.computed;
-
 /**
  * The base class for all torii providers
  * @class BaseProvider
  */
-var Base = Ember.Object.extend({
+var Base = EmberObject.extend({
 
  /**
   * The name of the provider

--- a/addon/providers/edmodo-connect.js
+++ b/addon/providers/edmodo-connect.js
@@ -1,5 +1,5 @@
 import Oauth2Bearer from 'torii/providers/oauth2-bearer';
-import {configurable} from 'torii/configuration';
+import { configurable } from 'torii/configuration';
 
 /*
 * This class implements authentication against Edmodo

--- a/addon/providers/facebook-connect.js
+++ b/addon/providers/facebook-connect.js
@@ -7,10 +7,14 @@
  * unless it detects the presence of the global `window.FB`.
  */
 
-import Provider from 'torii/providers/base';
-import {configurable} from 'torii/configuration';
+import { run } from '@ember/runloop';
 
-var on = Ember.on;
+import { Promise as EmberPromise } from 'rsvp';
+import { on } from '@ember/object/evented';
+
+import Provider from 'torii/providers/base';
+import { configurable } from 'torii/configuration';
+
 var fbPromise;
 
 function fbLoad(settings){
@@ -19,13 +23,13 @@ function fbLoad(settings){
   var original = window.fbAsyncInit;
   var locale = settings.locale;
   delete settings.locale;
-  fbPromise = new Ember.RSVP.Promise(function(resolve){
+  fbPromise = new EmberPromise(function(resolve){
     if (window.FB) {
       return resolve();
     }
     window.fbAsyncInit = function(){
       FB.init(settings);
-      Ember.run(null, resolve);
+      run(null, resolve);
     };
     $.getScript('//connect.facebook.net/' + locale + '/sdk.js');
   }).then(function(){
@@ -40,12 +44,12 @@ function fbLoad(settings){
 }
 
 function fbLogin(scope, returnScopes, authType){
-  return new Ember.RSVP.Promise(function(resolve, reject){
+  return new EmberPromise(function(resolve, reject){
     FB.login(function(response){
       if (response.authResponse) {
-        Ember.run(null, resolve, response.authResponse);
+        run(null, resolve, response.authResponse);
       } else {
-        Ember.run(null, reject, response.status);
+        run(null, reject, response.status);
       }
     }, { scope: scope, return_scopes: returnScopes, auth_type: authType });
   });

--- a/addon/providers/facebook-oauth2.js
+++ b/addon/providers/facebook-oauth2.js
@@ -1,4 +1,4 @@
-import {configurable} from 'torii/configuration';
+import { configurable } from 'torii/configuration';
 import Oauth2 from 'torii/providers/oauth2-code';
 
 export default Oauth2.extend({

--- a/addon/providers/github-oauth2.js
+++ b/addon/providers/github-oauth2.js
@@ -1,5 +1,5 @@
 import Oauth2 from 'torii/providers/oauth2-code';
-import {configurable} from 'torii/configuration';
+import { configurable } from 'torii/configuration';
 
 /**
  * This class implements authentication against Github

--- a/addon/providers/google-oauth2-bearer-v2.js
+++ b/addon/providers/google-oauth2-bearer-v2.js
@@ -1,6 +1,7 @@
+import $ from 'jquery';
+import { Promise as EmberPromise } from 'rsvp';
 import OAuth2Code from 'torii/providers/oauth2-code';
-import {configurable} from 'torii/configuration';
-import Ember from 'ember';
+import { configurable } from 'torii/configuration';
 
 /**
  * This class implements a provider allowing authentication against google's
@@ -76,9 +77,9 @@ var GoogleOauth2BearerV2 = OAuth2Code.extend({
 
       // Token validation. For details, see
       // https://developers.google.com/identity/protocols/OAuth2UserAgent#validatetoken
-      return new Ember.RSVP.Promise( function (resolve, reject) {
+      return new EmberPromise( function (resolve, reject) {
         // Token validation request
-        Ember.$.ajax(
+        $.ajax(
           {
             type: 'GET',
             url: tokenValidationUrl,

--- a/addon/providers/google-oauth2-bearer.js
+++ b/addon/providers/google-oauth2-bearer.js
@@ -4,7 +4,7 @@
  */
 
 import Oauth2Bearer from 'torii/providers/oauth2-bearer';
-import {configurable} from 'torii/configuration';
+import { configurable } from 'torii/configuration';
 
 var GoogleOauth2Bearer = Oauth2Bearer.extend({
 

--- a/addon/providers/google-oauth2.js
+++ b/addon/providers/google-oauth2.js
@@ -4,7 +4,7 @@
  */
 
 import Oauth2 from 'torii/providers/oauth2-code';
-import {configurable} from 'torii/configuration';
+import { configurable } from 'torii/configuration';
 
 var GoogleOauth2 = Oauth2.extend({
 

--- a/addon/providers/linked-in-oauth2.js
+++ b/addon/providers/linked-in-oauth2.js
@@ -1,5 +1,5 @@
 import Oauth2 from 'torii/providers/oauth2-code';
-import {configurable} from 'torii/configuration';
+import { configurable } from 'torii/configuration';
 
 /**
  * This class implements authentication against Linked In

--- a/addon/providers/oauth1.js
+++ b/addon/providers/oauth1.js
@@ -4,7 +4,7 @@
  */
 
 import Provider from 'torii/providers/base';
-import {configurable} from 'torii/configuration';
+import { configurable } from 'torii/configuration';
 
 var Oauth1 = Provider.extend({
   name: 'oauth1',

--- a/addon/providers/oauth2-code.js
+++ b/addon/providers/oauth2-code.js
@@ -1,10 +1,9 @@
+import { computed } from '@ember/object';
 import Provider from 'torii/providers/base';
-import {configurable} from 'torii/configuration';
+import { configurable } from 'torii/configuration';
 import QueryString from 'torii/lib/query-string';
 import requiredProperty from 'torii/lib/required-property';
 import randomUrlSafe from 'torii/lib/random-url-safe';
-
-var computed = Ember.computed;
 
 function currentUrl(){
   var url = [window.location.protocol,

--- a/addon/providers/stripe-connect.js
+++ b/addon/providers/stripe-connect.js
@@ -1,5 +1,5 @@
 import Oauth2 from 'torii/providers/oauth2-code';
-import {configurable} from 'torii/configuration';
+import { configurable } from 'torii/configuration';
 
 export default Oauth2.extend({
   name:       'stripe-connect',

--- a/addon/redirect-handler.js
+++ b/addon/redirect-handler.js
@@ -6,22 +6,27 @@
  * and should postMessage this data to window.opener
  */
 
+import { Promise as EmberPromise } from 'rsvp';
+
+import EmberObject from '@ember/object';
+import EmberError from '@ember/error';
+
 import { CURRENT_REQUEST_KEY, WARNING_KEY } from "./mixins/ui-service-mixin";
 import configuration from 'torii/configuration';
 
-export class ToriiRedirectError extends Ember.Error {
+export class ToriiRedirectError extends EmberError {
   constructor() {
     super(...arguments);
     this.name = 'ToriiRedirectError';
   }
 }
 
-var RedirectHandler = Ember.Object.extend({
+var RedirectHandler = EmberObject.extend({
 
   run: function(){
     var windowObject = this.windowObject;
 
-    return new Ember.RSVP.Promise(function(resolve, reject){
+    return new EmberPromise(function(resolve, reject){
       var pendingRequestKey = windowObject.localStorage.getItem(CURRENT_REQUEST_KEY);
       windowObject.localStorage.removeItem(CURRENT_REQUEST_KEY);
       if (pendingRequestKey) {

--- a/addon/router-dsl-ext.js
+++ b/addon/router-dsl-ext.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import Router from '@ember/routing/router';
 import getRouterLib from 'torii/compat/get-router-lib';
 

--- a/addon/router-dsl-ext.js
+++ b/addon/router-dsl-ext.js
@@ -1,6 +1,6 @@
+import Router from '@ember/routing/router';
 import getRouterLib from 'torii/compat/get-router-lib';
 
-var Router = Ember.Router;
 var proto = Ember.RouterDSL.prototype;
 
 var currentMap = null;

--- a/addon/routing/application-route-mixin.js
+++ b/addon/routing/application-route-mixin.js
@@ -1,6 +1,7 @@
+import Mixin from '@ember/object/mixin';
 import { getConfiguration } from 'torii/configuration';
 
-export default Ember.Mixin.create({
+export default Mixin.create({
   beforeModel: function (transition) {
     var route = this;
     var superBefore = this._super.apply(this, arguments);

--- a/addon/routing/authenticated-route-mixin.js
+++ b/addon/routing/authenticated-route-mixin.js
@@ -1,6 +1,8 @@
+import { resolve } from 'rsvp';
+import Mixin from '@ember/object/mixin';
 import { getConfiguration } from 'torii/configuration';
 
-export default Ember.Mixin.create({
+export default Mixin.create({
   beforeModel: function (transition) {
     var route = this;
     var superBefore = this._super.apply(this, arguments);
@@ -32,7 +34,7 @@ export default Ember.Mixin.create({
       }
     } else {
       // no-op; cause the user is already authenticated
-      return Ember.RSVP.resolve();
+      return resolve();
     }
   },
   accessDenied: function (transition) {

--- a/addon/services/iframe.js
+++ b/addon/services/iframe.js
@@ -1,11 +1,14 @@
+import $ from 'jquery';
+import Evented from '@ember/object/evented';
+import EmberObject from '@ember/object';
 import UiServiceMixin from 'torii/mixins/ui-service-mixin';
 
-var Iframe = Ember.Object.extend(Ember.Evented, UiServiceMixin, {
+var Iframe = EmberObject.extend(Evented, UiServiceMixin, {
 
   openRemote: function(url){
-    this.remote = Ember.$('<iframe src="'+url+'" id="torii-iframe"></iframe>');
+    this.remote = $('<iframe src="'+url+'" id="torii-iframe"></iframe>');
     var iframeParent = '.torii-iframe-placeholder';
-    Ember.$(iframeParent).append(this.remote);
+    $(iframeParent).append(this.remote);
   },
 
   closeRemote: function(){
@@ -13,7 +16,7 @@ var Iframe = Ember.Object.extend(Ember.Evented, UiServiceMixin, {
   },
 
   pollRemote: function(){
-    if (Ember.$('#torii-iframe').length === 0) {
+    if ($('#torii-iframe').length === 0) {
       this.trigger('didClose');
     }
   }

--- a/addon/services/popup.js
+++ b/addon/services/popup.js
@@ -1,3 +1,6 @@
+import Evented from '@ember/object/evented';
+import EmberObject from '@ember/object';
+import $ from 'jquery';
 import UiServiceMixin from 'torii/mixins/ui-service-mixin';
 
 function stringifyOptions(options){
@@ -26,7 +29,7 @@ function stringifyOptions(options){
 function prepareOptions(options){
   var width = options.width || 500,
       height = options.height || 500;
-  return Ember.$.extend({
+  return $.extend({
     left: ((screen.width / 2) - (width / 2)),
     top: ((screen.height / 2) - (height / 2)),
     width: width,
@@ -34,7 +37,7 @@ function prepareOptions(options){
   }, options);
 }
 
-var Popup = Ember.Object.extend(Ember.Evented, UiServiceMixin, {
+var Popup = EmberObject.extend(Evented, UiServiceMixin, {
 
   // Open a popup window.
   openRemote: function(url, pendingRequestKey, options){

--- a/addon/services/torii-session.js
+++ b/addon/services/torii-session.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { Promise as EmberPromise, reject } from 'rsvp';
 import Service from '@ember/service';
 import { on } from '@ember/object/evented';

--- a/addon/services/torii-session.js
+++ b/addon/services/torii-session.js
@@ -1,8 +1,9 @@
+import { Promise as EmberPromise, reject } from 'rsvp';
+import Service from '@ember/service';
+import { on } from '@ember/object/evented';
+import { computed } from '@ember/object';
 import createStateMachine from 'torii/session/state-machine';
 import { getOwner } from 'torii/lib/container-utils';
-
-var computed = Ember.computed;
-var on = Ember.on;
 
 function lookupAdapter(container, authenticationType){
   var adapter = container.lookup('torii-adapter:'+authenticationType);
@@ -12,7 +13,7 @@ function lookupAdapter(container, authenticationType){
   return adapter;
 }
 
-export default Ember.Service.extend(Ember._ProxyMixin, {
+export default Service.extend(Ember._ProxyMixin, {
   state: null,
 
   stateMachine: computed(function(){
@@ -36,7 +37,7 @@ export default Ember.Service.extend(Ember._ProxyMixin, {
         torii     = getOwner(this).lookup('service:torii'),
         sm        = this.get('stateMachine');
 
-    return new Ember.RSVP.Promise(function(resolve){
+    return new EmberPromise(function(resolve){
       sm.send('startOpen');
       resolve();
     }).then(function(){
@@ -52,7 +53,7 @@ export default Ember.Service.extend(Ember._ProxyMixin, {
       return user;
     }).catch(function(error){
       sm.send('failOpen', error);
-      return Ember.RSVP.reject(error);
+      return reject(error);
     });
   },
 
@@ -60,7 +61,7 @@ export default Ember.Service.extend(Ember._ProxyMixin, {
     var owner     = getOwner(this),
         sm        = this.get('stateMachine');
 
-    return new Ember.RSVP.Promise(function(resolve){
+    return new EmberPromise(function(resolve){
       sm.send('startFetch');
       resolve();
     }).then(function(){
@@ -74,7 +75,7 @@ export default Ember.Service.extend(Ember._ProxyMixin, {
       return;
     }).catch(function(error){
       sm.send('failFetch', error);
-      return Ember.RSVP.reject(error);
+      return reject(error);
     });
   },
 
@@ -82,7 +83,7 @@ export default Ember.Service.extend(Ember._ProxyMixin, {
     var owner     = getOwner(this),
         sm        = this.get('stateMachine');
 
-    return new Ember.RSVP.Promise(function(resolve){
+    return new EmberPromise(function(resolve){
       sm.send('startClose');
       resolve();
     }).then(function(){
@@ -92,7 +93,7 @@ export default Ember.Service.extend(Ember._ProxyMixin, {
       sm.send('finishClose');
     }).catch(function(error){
       sm.send('failClose', error);
-      return Ember.RSVP.reject(error);
+      return reject(error);
     });
   }
 });

--- a/addon/services/torii.js
+++ b/addon/services/torii.js
@@ -1,3 +1,5 @@
+import Service from '@ember/service';
+import { Promise as EmberPromise } from 'rsvp';
 import { getOwner } from 'torii/lib/container-utils';
 
 function lookupProvider(container, providerName){
@@ -18,10 +20,10 @@ function proxyToProvider(methodName, requireMethod){
         throw new Error("Expected provider '"+providerName+"' to define " +
                         "the '"+methodName+"' method.");
       } else {
-        return Ember.RSVP.Promise.resolve({});
+        return EmberPromise.resolve({});
       }
     }
-    return new Ember.RSVP.Promise(function(resolve){
+    return new EmberPromise(function(resolve){
       resolve( provider[methodName](options) );
     });
   };
@@ -43,7 +45,7 @@ function proxyToProvider(methodName, requireMethod){
  *
  * @class Torii
  */
-export default Ember.Service.extend({
+export default Service.extend({
 
   /**
    * Open an authorization against an API. A promise resolving

--- a/app/instance-initializers/setup-routes.js
+++ b/app/instance-initializers/setup-routes.js
@@ -6,7 +6,7 @@ import "torii/router-dsl-ext";
 
 export default {
   name: 'torii-setup-routes',
-  initialize: function(applicationInstance, registry){
+  initialize(applicationInstance /*, registry */){
     const configuration = getConfiguration();
 
     if (!configuration.sessionServiceName) {

--- a/app/instance-initializers/setup-routes.js
+++ b/app/instance-initializers/setup-routes.js
@@ -1,3 +1,6 @@
+/* eslint-disable ember/new-module-imports */
+
+import Ember from 'ember';
 import bootstrapRouting from 'torii/bootstrap/routing';
 import { getConfiguration } from 'torii/configuration';
 import getRouterInstance from 'torii/compat/get-router-instance';

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.3.0"
+    "ember-cli-babel": "^6.8.2"
   },
   "devDependencies": {
     "bower": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "bower": "^1.8.0",
     "broccoli-asset-rev": "^2.4.5",
-    "ember-cli": "~2.15.0",
+    "ember-cli": "~2.16.2",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.0",
     "ember-cli-htmlbars": "^2.0.1",
@@ -59,12 +59,12 @@
     "ember-cli-qunit": "^4.0.1",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-uglify": "^1.2.0",
+    "ember-cli-uglify": "^2.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.5.0",
-    "ember-source": "~2.15.0",
+    "ember-source": "~2.16.0",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.5.0",
     "ember-source": "~2.16.0",
+    "eslint-plugin-ember": "^5.0.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/test-support/helpers/torii.js
+++ b/test-support/helpers/torii.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 import config from '../../config/environment';
 
 const {
@@ -8,7 +9,7 @@ export function stubValidSession(application, sessionData) {
   let session = application.__container__.lookup(`service:${sessionServiceName}`);
 
   let sm = session.get('stateMachine');
-  Ember.run(() => {
+  run(() => {
     sm.send('startOpen');
     sm.send('finishOpen', sessionData);
   });

--- a/testem.js
+++ b/testem.js
@@ -9,11 +9,14 @@ module.exports = {
     'Chrome'
   ],
   browser_args: {
-    Chrome: [
-      '--disable-gpu',
-      '--headless',
-      '--remote-debugging-port=9222',
-      '--window-size=1440,900'
-    ]
+    Chrome: {
+      mode: 'ci',
+      args: [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=9222',
+        '--window-size=1440,900'
+      ]
+    },
   }
 };

--- a/tests/acceptance/ember-init-test.js
+++ b/tests/acceptance/ember-init-test.js
@@ -1,3 +1,7 @@
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+import Controller from '@ember/controller';
+import { run } from '@ember/runloop';
 import startApp from '../helpers/start-app';
 import configuration from '../../config/environment';
 import lookup from '../helpers/lookup';
@@ -22,7 +26,7 @@ module('Ember Initialization - Acceptance', {
 
   afterEach() {
     toriiConfiguration.sessionServiceName = originalSessionServiceName;
-    Ember.run(this.application, 'destroy');
+    run(this.application, 'destroy');
   }
 });
 
@@ -30,7 +34,7 @@ test('session is not injected by default', function(assert){
   this.application = startApp();
   assert.ok(!lookup(this.application, 'service:session'));
 
-  this.application.register('controller:application', Ember.Controller.extend());
+  this.application.register('controller:application', Controller.extend());
   var controller = lookup(this.application, 'controller:application');
   assert.ok(!controller.get('session'), 'controller has no session');
 });
@@ -41,7 +45,7 @@ test('session is injected with the name in the configuration', function(assert){
   this.application = startApp();
   assert.ok(lookup(this.application, 'service:wackySessionName'), 'service:wackySessionName is injected');
 
-  this.application.register('controller:application', Ember.Controller.extend());
+  this.application.register('controller:application', Controller.extend());
   var controller = lookup(this.application, 'controller:application');
 
   assert.ok(controller.get('wackySessionName'),
@@ -57,9 +61,9 @@ test('session is injectable using inject.service', function(assert){
   this.application = startApp();
   assert.ok(lookup(this.application, 'service:session'), 'service:session is injected');
 
-  this.application.register('component:testComponent', Ember.Component.extend({
-    session: Ember.inject.service('session'),
-    torii: Ember.inject.service('torii')
+  this.application.register('component:testComponent', Component.extend({
+    session: service('session'),
+    torii: service('torii')
   }));
 
   var DummyRenderer = { componentInitAttrs() {} };

--- a/tests/acceptance/routing-test.js
+++ b/tests/acceptance/routing-test.js
@@ -1,9 +1,10 @@
+import Route from '@ember/routing/route';
+import { run } from '@ember/runloop';
 import startApp from '../helpers/start-app';
 import rawConfig from '../../config/environment';
 import lookup from '../helpers/lookup';
 import Router from 'dummy/router';
 import QUnit from 'qunit';
-import Ember from 'ember';
 
 let { module, test } = QUnit;
 
@@ -18,7 +19,7 @@ module('Routing - Acceptance', {
 
   afterEach() {
     configuration.sessionServiceName = originalSessionServiceName;
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
@@ -34,7 +35,7 @@ test('ApplicationRoute#checkLogin is not called when no authenticated routes are
       routesConfigured = true;
     },
     setup: function() {
-      app.register('route:application', Ember.Route.extend());
+      app.register('route:application', Route.extend());
     }
   });
   var applicationRoute = lookup(app, 'route:application');
@@ -61,8 +62,8 @@ test('ApplicationRoute#checkLogin is called when an authenticated route is prese
       this.authenticatedRoute('account');
     },
     setup: function() {
-      app.register('route:application', Ember.Route.extend());
-      app.register('route:account', Ember.Route.extend());
+      app.register('route:application', Route.extend());
+      app.register('route:account', Route.extend());
     }
   });
   var applicationRoute = lookup(app, 'route:application');
@@ -90,8 +91,8 @@ test('ApplicationRoute#checkLogin returns the correct name of the session variab
       this.authenticatedRoute('account');
     },
     setup: function() {
-      app.register('route:application', Ember.Route.extend());
-      app.register('route:account', Ember.Route.extend());
+      app.register('route:application', Route.extend());
+      app.register('route:account', Route.extend());
     }
   });
   var applicationRoute = lookup(app, 'route:application');
@@ -118,9 +119,9 @@ test('authenticated routes get authenticate method', function(assert){
       this.authenticatedRoute('account');
     },
     setup: function() {
-      app.register('route:application', Ember.Route.extend());
-      app.register('route:account', Ember.Route.extend());
-      app.register('route:home', Ember.Route.extend());
+      app.register('route:application', Route.extend());
+      app.register('route:account', Route.extend());
+      app.register('route:home', Route.extend());
     }
   });
   var authenticatedRoute = lookup(app, 'route:account');
@@ -160,8 +161,8 @@ test('session.attemptedTransition is set before redirecting away from authentica
       this.authenticatedRoute('secret');
     },
     setup: function() {
-      app.register('route:application', Ember.Route.extend());
-      app.register('route:secret', Ember.Route.extend());
+      app.register('route:application', Route.extend());
+      app.register('route:secret', Route.extend());
     }
   });
 
@@ -195,7 +196,7 @@ function bootApp(attrs) {
 
   setup();
 
-  Ember.run(function(){
+  run(function(){
     app.advanceReadiness();
   });
 

--- a/tests/acceptance/session-test.js
+++ b/tests/acceptance/session-test.js
@@ -1,9 +1,10 @@
+import { Promise as EmberPromise } from 'rsvp';
+import { run } from '@ember/runloop';
 import DummyAdapter from '../helpers/dummy-adapter';
 import DummySuccessProvider from '../helpers/dummy-success-provider';
 import DummyFailureProvider from '../helpers/dummy-failure-provider';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import { test } from 'qunit';
-import Ember from 'ember';
 
 function signIn(session, sessionData={}){
   var sm = session.get('stateMachine');
@@ -24,7 +25,7 @@ moduleForAcceptance('Session - Acceptance', {
 });
 
 test("#open dummy-success session raises must-implement on application adapter", function(assert){
-  Ember.run(() => {
+  run(() => {
     this.session.open('dummy-success').then(() => {
       assert.ok(false, 'resolved promise');
     }, function(error){
@@ -36,7 +37,7 @@ test("#open dummy-success session raises must-implement on application adapter",
 
 test("#open dummy-success session fails on signed in state", function(assert){
   signIn(this.session);
-  Ember.run(() => {
+  run(() => {
     this.session.open('dummy-success').then(() => {
       assert.ok(false, 'resolved promise');
     }, function(error){
@@ -48,7 +49,7 @@ test("#open dummy-success session fails on signed in state", function(assert){
 
 test("#open dummy-success session successfully opens", function(assert){
   this.application.register("torii-adapter:dummy-success", DummyAdapter);
-  Ember.run(() => {
+  run(() => {
     this.session.open('dummy-success').then(() => {
       assert.ok(true, 'resolves promise');
       assert.ok(this.session.get('isAuthenticated'), 'authenticated');
@@ -60,7 +61,7 @@ test("#open dummy-success session successfully opens", function(assert){
 });
 
 test("#open dummy-failure session fails to open", function(assert){
-  Ember.run(() => {
+  run(() => {
     this.session.open('dummy-failure').then(function(){
       assert.ok(false, 'should not resolve promise');
     }, function(){
@@ -70,7 +71,7 @@ test("#open dummy-failure session fails to open", function(assert){
 });
 
 test("#fetch dummy-success session raises must-implement on application adapter", function(assert){
-  Ember.run(() => {
+  run(() => {
     this.session.fetch('dummy-success').then(function(){
       assert.ok(false, 'resolved promise');
     }, function(error){
@@ -83,7 +84,7 @@ test("#fetch dummy-success session raises must-implement on application adapter"
 test("#fetch dummy-success session fails on signed in state", function(assert){
   this.application.register("torii-adapter:dummy-success", DummyAdapter);
   signIn(this.session);
-  Ember.run(() => {
+  run(() => {
     this.session.fetch('dummy-success').then(function(){
       assert.ok(false, 'resolved promise');
     }, function(error){
@@ -95,7 +96,7 @@ test("#fetch dummy-success session fails on signed in state", function(assert){
 
 test("#fetch dummy-success session successfully opens", function(assert){
   this.application.register("torii-adapter:dummy-success", DummyAdapter);
-  Ember.run(() => {
+  run(() => {
     this.session.fetch('dummy-success').then(() => {
       assert.ok(true, 'resolves promise');
       assert.ok(this.session.get('isAuthenticated'), 'authenticated');
@@ -114,7 +115,7 @@ test("#fetch session passes options to adapter", function(assert){
       return this._super(options);
     }
   }));
-  Ember.run(() => {
+  run(() => {
     var opts = {};
     this.session.fetch('dummy-success', opts).then(function(){
       assert.equal(adapterFetchCalledWith, opts, 'options should be passed through to adapter');
@@ -125,7 +126,7 @@ test("#fetch session passes options to adapter", function(assert){
 });
 
 test("#fetch dummy-failure session fails to open", function(assert){
-  Ember.run(() => {
+  run(() => {
     this.session.open('dummy-failure').then(function(){
       assert.ok(false, 'should not resolve promise');
     }, function(){
@@ -137,10 +138,10 @@ test("#fetch dummy-failure session fails to open", function(assert){
 test("#close dummy-success fails in an unauthenticated state", function(assert){
   this.adapter.reopen({
     close: function(){
-      return Ember.RSVP.Promise.resolve();
+      return EmberPromise.resolve();
     }
   });
-  Ember.run(() => {
+  run(() => {
     this.session.close().then(function(){
       assert.ok(false, 'resolved promise');
     }, function(error){
@@ -154,10 +155,10 @@ test("#close dummy-success session closes", function(assert){
   signIn(this.session, {currentUser: {email: 'some@email.com'}});
   this.adapter.reopen({
     close: function(){
-      return Ember.RSVP.Promise.resolve();
+      return EmberPromise.resolve();
     }
   });
-  Ember.run(() => {
+  run(() => {
     this.session.close('dummy-success').then(() => {
       assert.ok(true, 'resolved promise');
       assert.ok(!this.session.get('isAuthenticated'), 'authenticated');
@@ -170,7 +171,7 @@ test("#close dummy-success session closes", function(assert){
 
 test("#close dummy-success session raises must-implement on application adapter", function(assert){
   signIn(this.session);
-  Ember.run(() => {
+  run(() => {
     this.session.close('dummy-success').then(function(){
       assert.ok(false, 'resolved promise');
     }, function(error){
@@ -186,10 +187,10 @@ test("#close dummy-success session passes options to application adapter", funct
 
   this.adapter.close = function(options) {
     optionsCloseCalledWith = options;
-    return new Ember.RSVP.Promise(function (resolve) { resolve(); });
+    return new EmberPromise(function (resolve) { resolve(); });
   };
 
-  Ember.run(() => {
+  run(() => {
     var opts = {};
     this.session.close('dummy-success', opts).then(function(){
       assert.equal(optionsCloseCalledWith, opts, 'options should be passed through to adapter');
@@ -206,7 +207,7 @@ test("#close dummy-success session uses named adapter when present", function(as
       return this._super();
     }
   }));
-  Ember.run(() => {
+  run(() => {
     this.session.close('dummy-success').then(function(){
       assert.ok(correctAdapterCalled, 'named adapter should be used');
     }, function(err){

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-const App = Ember.Application.extend({
+const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,11 +1,14 @@
-import Ember from 'ember';
+import { A } from '@ember/array';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
 import config from '../config/environment';
 
-export default Ember.Controller.extend({
-  torii: Ember.inject.service(),
+export default Controller.extend({
+  torii: service(),
 
-  providers: Ember.computed(function() {
-    return Ember.A(Object.keys(config.torii.providers));
+  providers: computed(function() {
+    return A(Object.keys(config.torii.providers));
   }),
 
   actions: {

--- a/tests/dummy/app/helpers/inspect-object.js
+++ b/tests/dummy/app/helpers/inspect-object.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
+import { htmlSafe } from '@ember/string';
 
 export function inspectObject([obj]/*, hash*/) {
-  return Ember.String.htmlSafe(JSON.stringify(obj));
+  return htmlSafe(JSON.stringify(obj));
 }
 
-export default Ember.Helper.helper(inspectObject);
+export default helper(inspectObject);

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -82,7 +82,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-
+    // here you can enable a production-specific feature
   }
 
   return ENV;

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/helpers/dummy-adapter.js
+++ b/tests/helpers/dummy-adapter.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { resolve } from 'rsvp';
+import EmberObject from '@ember/object';
 
-var dummyUser = Ember.Object.create({
+var dummyUser = EmberObject.create({
   email: 'someUser@example.com'
 });
 
-export default Ember.Object.extend({
+export default EmberObject.extend({
   open: function(){
-    return Ember.RSVP.resolve({
+    return resolve({
       currentUser: dummyUser
     });
   },
   fetch: function(){
-    return Ember.RSVP.resolve({
+    return resolve({
       currentUser: dummyUser
     });
   }

--- a/tests/helpers/dummy-failure-provider.js
+++ b/tests/helpers/dummy-failure-provider.js
@@ -2,10 +2,14 @@
  * This class emulates a failed authentication.
  */
 
-export default Ember.Object.extend({
+import { reject } from 'rsvp';
+
+import EmberObject from '@ember/object';
+
+export default EmberObject.extend({
 
   open: function(){
-    return Ember.RSVP.reject("Dummy authentication failure");
+    return reject("Dummy authentication failure");
   }
 
 });

--- a/tests/helpers/dummy-success-provider.js
+++ b/tests/helpers/dummy-success-provider.js
@@ -3,10 +3,14 @@
  * a dummy authorization object.
  */
 
-export default Ember.Object.extend({
+import { Promise as EmberPromise } from 'rsvp';
+
+import EmberObject from '@ember/object';
+
+export default EmberObject.extend({
 
   open: function(authorization){
-    return Ember.RSVP.Promise.resolve(authorization);
+    return EmberPromise.resolve(authorization);
   }
 
 });

--- a/tests/helpers/mock-popup.js
+++ b/tests/helpers/mock-popup.js
@@ -1,3 +1,4 @@
+import { resolve } from 'rsvp';
 import ParseQueryString from 'torii/lib/parse-query-string';
 
 var MockPopup = function(options) {
@@ -24,7 +25,7 @@ MockPopup.prototype.open = function(url, keys){
     response.state = state;
   }
 
-  return Ember.RSVP.resolve(response);
+  return resolve(response);
 };
 
 export default MockPopup;

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,9 +1,7 @@
+import { resolve } from 'rsvp';
 import { module } from 'qunit';
-import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-
-const { RSVP: { resolve } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,5 +1,5 @@
-import { resolve } from 'rsvp';
 import { module } from 'qunit';
+import { resolve } from 'rsvp';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
+import { merge } from '@ember/polyfills';
 import Application from '../../app';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
-  return Ember.run(() => {
+  return run(() => {
     let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,7 +1,7 @@
-import { run } from '@ember/runloop';
-import { merge } from '@ember/polyfills';
 import Application from '../../app';
 import config from '../../config/environment';
+import { merge } from '@ember/polyfills';
+import { run } from '@ember/runloop';
 
 export default function startApp(attrs) {
   let attributes = merge({}, config.APP);

--- a/tests/integration/providers/azure-ad-oauth2-test.js
+++ b/tests/integration/providers/azure-ad-oauth2-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 var torii, app;
 
 import { configure } from 'torii/configuration';
@@ -31,12 +32,12 @@ module('AzureAd - Integration', {
 
   afterEach() {
     mockPopup.opened = false;
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
 test("Opens a popup to AzureAd", function(assert){
-  Ember.run(function(){
+  run(function(){
     torii.open('azure-ad-oauth2').finally(function(){
       assert.ok(mockPopup.opened, "Popup service is opened");
     });
@@ -46,7 +47,7 @@ test("Opens a popup to AzureAd", function(assert){
 test('Validates the state parameter in the response', function(assert){
   app.inject('torii-provider', 'popup', 'torii-service:fail-popup');
 
-  Ember.run(function(){
+  run(function(){
     torii.open('azure-ad-oauth2').then(null, function(e){
       assert.ok(/has an incorrect session state/.test(e.message),
          'authentication fails due to invalid session state response');

--- a/tests/integration/providers/edmodo-connect-test.js
+++ b/tests/integration/providers/edmodo-connect-test.js
@@ -1,3 +1,5 @@
+import { run } from '@ember/runloop';
+import { resolve } from 'rsvp';
 var torii, app;
 
 import startApp from '../../helpers/start-app';
@@ -15,7 +17,7 @@ module('Edmodo Connect - Integration', {
     mockPopup = {
       open: function(){
         opened = true;
-        return Ember.RSVP.resolve({ access_token: 'test' });
+        return resolve({ access_token: 'test' });
       }
     };
     app.register('torii-service:mock-popup', mockPopup, {instantiate: false});
@@ -34,13 +36,13 @@ module('Edmodo Connect - Integration', {
   },
   afterEach() {
     opened = false;
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
 test("Opens a popup to Edmodo", function(assert){
   assert.expect(1);
-  Ember.run(function(){
+  run(function(){
     torii.open('edmodo-connect').finally(function(){
       assert.ok(opened, "Popup service is opened");
     });

--- a/tests/integration/providers/facebook-connect-test.js
+++ b/tests/integration/providers/facebook-connect-test.js
@@ -1,12 +1,13 @@
+import { merge } from '@ember/polyfills';
+import { run } from '@ember/runloop';
+import $ from 'jquery';
 import buildFBMock from '../../helpers/build-fb-mock';
 import { configure } from 'torii/configuration';
 import startApp from '../../helpers/start-app';
 import lookup from '../../helpers/lookup';
 import QUnit from 'qunit';
-import Ember from 'ember';
 
 const { module, test } = QUnit;
-const { $ } = Ember;
 
 var originalGetScript = $.getScript,
     originalFB = window.FB;
@@ -31,7 +32,7 @@ module('Facebook Connect - Integration', {
   afterEach() {
     window.FB = originalFB;
     $.getScript = originalGetScript;
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
@@ -39,7 +40,7 @@ test("Opens facebook connect session", function(assert){
   $.getScript = function(){
     window.fbAsyncInit();
   };
-  Ember.run(function(){
+  run(function(){
     torii.open('facebook-connect').then(function(){
       assert.ok(true, "Facebook connect opened");
     }, function(e){
@@ -54,10 +55,10 @@ test("Returns the scopes granted when configured", function(assert){
   };
   configure({
     providers: {
-      'facebook-connect': Ember.merge(providerConfiguration, {returnScopes: true})
+      'facebook-connect': merge(providerConfiguration, {returnScopes: true})
     }
   });
-  Ember.run(function(){
+  run(function(){
     torii.open('facebook-connect').then(function(data){
       assert.equal('email', data.grantedScopes);
     });
@@ -68,7 +69,7 @@ test("Supports custom auth_type on login", function(assert){
   $.getScript = function(){
     window.fbAsyncInit();
   };
-  Ember.run(function(){
+  run(function(){
     torii.open('facebook-connect', {authType: 'rerequest'}).then(function(data){
       assert.equal(5678, data.expiresIn, 'expriesIn extended when rerequest found');
     });

--- a/tests/integration/providers/facebook-oauth2-test.js
+++ b/tests/integration/providers/facebook-oauth2-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 var torii, app;
 
 import { configure } from 'torii/configuration';
@@ -28,12 +29,12 @@ module('Facebook OAuth2 - Integration', {
   },
   afterEach() {
     mockPopup.opened = false;
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
 test("Opens a popup to Facebook", function(assert){
-  Ember.run(function(){
+  run(function(){
     torii.open('facebook-oauth2').finally(function(){
       assert.ok(mockPopup.opened, "Popup service is opened");
     });
@@ -41,7 +42,7 @@ test("Opens a popup to Facebook", function(assert){
 });
 
 test("Resolves with an authentication object containing 'redirectUri'", function(assert){
-  Ember.run(function(){
+  run(function(){
     torii.open('facebook-oauth2').then(function(data){
       assert.ok(data.redirectUri,
          'Object has redirectUri');
@@ -54,7 +55,7 @@ test("Resolves with an authentication object containing 'redirectUri'", function
 test('Validates the state parameter in the response', function(assert){
   app.inject('torii-provider', 'popup', 'torii-service:fail-popup');
 
-  Ember.run(function(){
+  run(function(){
     torii.open('facebook-oauth2').then(null, function(e){
       assert.ok(/has an incorrect session state/.test(e.message),
          'authentication fails due to invalid session state response');

--- a/tests/integration/providers/github-oauth2-test.js
+++ b/tests/integration/providers/github-oauth2-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 var torii, app;
 
 import { configure } from 'torii/configuration';
@@ -28,12 +29,12 @@ module('Github - Integration', {
   },
   afterEach() {
     mockPopup.opened = false;
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
 test("Opens a popup to GitHub", function(assert){
-  Ember.run(function(){
+  run(function(){
     torii.open('github-oauth2').finally(function(){
       assert.ok(mockPopup.opened, "Popup service is opened");
     });
@@ -43,7 +44,7 @@ test("Opens a popup to GitHub", function(assert){
 test('Validates the state parameter in the response', function(assert){
   app.inject('torii-provider', 'popup', 'torii-service:fail-popup');
 
-  Ember.run(function(){
+  run(function(){
     torii.open('github-oauth2').then(null, function(e){
       assert.ok(/has an incorrect session state/.test(e.message),
          'authentication fails due to invalid session state response');

--- a/tests/integration/providers/google-oauth2-bearer-test.js
+++ b/tests/integration/providers/google-oauth2-bearer-test.js
@@ -1,3 +1,6 @@
+import { merge } from '@ember/polyfills';
+import { run } from '@ember/runloop';
+import { resolve } from 'rsvp';
 var torii, app;
 
 import { configure } from 'torii/configuration';
@@ -14,7 +17,7 @@ module('Google Bearer- Integration', {
     mockPopup = {
       open: function(){
         opened = true;
-        return Ember.RSVP.resolve({ access_token: 'test' });
+        return resolve({ access_token: 'test' });
       }
     };
     app = startApp({loadInitializers: true});
@@ -31,13 +34,13 @@ module('Google Bearer- Integration', {
   },
   afterEach() {
     opened = false;
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
 test("Opens a popup to Google", function(assert){
   assert.expect(1);
-  Ember.run(function(){
+  run(function(){
     torii.open('google-oauth2-bearer').finally(function(){
       assert.ok(opened, "Popup service is opened");
     });
@@ -48,7 +51,7 @@ test("Opens a popup to Google with request_visible_actions", function(assert){
   assert.expect(1);
   configure({
     providers: {
-      'google-oauth2-bearer': Ember.merge(providerConfig, {
+      'google-oauth2-bearer': merge(providerConfig, {
         requestVisibleActions: "http://some-url.com"
       })
     }
@@ -57,9 +60,9 @@ test("Opens a popup to Google with request_visible_actions", function(assert){
     assert.ok(
       url.indexOf("request_visible_actions=http%3A%2F%2Fsome-url.com") > -1,
       "request_visible_actions is present" );
-    return Ember.RSVP.resolve({ access_token: 'test' });
+    return resolve({ access_token: 'test' });
   };
-  Ember.run(function(){
+  run(function(){
     torii.open('google-oauth2-bearer');
   });
 });

--- a/tests/integration/providers/google-oauth2-test.js
+++ b/tests/integration/providers/google-oauth2-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 var torii, app;
 
 import { configure } from 'torii/configuration';
@@ -28,12 +29,12 @@ module('Google - Integration', {
   },
   afterEach() {
     mockPopup.opened = false;
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
 test("Opens a popup to Google", function(assert){
-  Ember.run(function(){
+  run(function(){
     torii.open('google-oauth2').finally(function(){
       assert.ok(mockPopup.opened, "Popup service is opened");
     });
@@ -43,7 +44,7 @@ test("Opens a popup to Google", function(assert){
 test('Validates the state parameter in the response', function(assert){
   app.inject('torii-provider', 'popup', 'torii-service:fail-popup');
 
-  Ember.run(function(){
+  run(function(){
     torii.open('google-oauth2').then(null, function(e){
       assert.ok(/has an incorrect session state/.test(e.message),
          'authentication fails due to invalid session state response');

--- a/tests/integration/providers/linked-in-oauth2-test.js
+++ b/tests/integration/providers/linked-in-oauth2-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 var torii, app;
 
 import { configure } from 'torii/configuration';
@@ -28,12 +29,12 @@ module('Linked In - Integration', {
   },
   afterEach() {
     mockPopup.opened = false;
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
 test("Opens a popup to Linked In", function(assert){
-  Ember.run(function(){
+  run(function(){
     torii.open('linked-in-oauth2').finally(function(){
       assert.ok(mockPopup.opened, "Popup service is opened");
     });
@@ -43,7 +44,7 @@ test("Opens a popup to Linked In", function(assert){
 test('Validates the state parameter in the response', function(assert){
   app.inject('torii-provider', 'popup', 'torii-service:fail-popup');
 
-  Ember.run(function(){
+  run(function(){
     torii.open('linked-in-oauth2').then(null, function(e){
       assert.ok(/has an incorrect session state/.test(e.message),
          'authentication fails due to invalid session state response');

--- a/tests/integration/providers/oauth1-test.js
+++ b/tests/integration/providers/oauth1-test.js
@@ -1,3 +1,5 @@
+import { run } from '@ember/runloop';
+import { resolve } from 'rsvp';
 import OAuth1Provider from 'torii/providers/oauth1';
 import { configure } from 'torii/configuration';
 import startApp from '../../helpers/start-app';
@@ -12,7 +14,7 @@ var opened, openedUrl, mockPopup = {
   open: function(url){
     openedUrl = url;
     opened = true;
-    return Ember.RSVP.resolve({});
+    return resolve({});
   }
 };
 
@@ -38,12 +40,12 @@ module('Oauth1 - Integration', {
   },
   afterEach() {
     opened = false;
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
 test("Opens a popup to the requestTokenUri", function(assert){
-  Ember.run(function(){
+  run(function(){
     torii.open(providerName).finally(function(){
       assert.equal(openedUrl, requestTokenUri, 'opens with requestTokenUri');
       assert.ok(opened, "Popup service is opened");

--- a/tests/integration/providers/stripe-connect-test.js
+++ b/tests/integration/providers/stripe-connect-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 import { configure } from 'torii/configuration';
 import MockPopup from '../../helpers/mock-popup';
 import startApp from '../../helpers/start-app';
@@ -28,12 +29,12 @@ module('Stripe Connect - Integration', {
   },
   afterEach() {
     mockPopup.opened = false;
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
 test("Opens a popup to Stripe", function(assert){
-  Ember.run(function(){
+  run(function(){
     torii.open('stripe-connect').finally(function(){
       assert.ok(mockPopup.opened, "Popup service is opened");
     });
@@ -43,7 +44,7 @@ test("Opens a popup to Stripe", function(assert){
 test('Validates the state parameter in the response', function(assert){
   app.inject('torii-provider', 'popup', 'torii-service:fail-popup');
 
-  Ember.run(function(){
+  run(function(){
     torii.open('stripe-connect').then(null, function(e){
       assert.ok(/has an incorrect session state/.test(e.message),
          'authentication fails due to invalid session state response');

--- a/tests/integration/session-test.js
+++ b/tests/integration/session-test.js
@@ -1,3 +1,5 @@
+import { resolve, reject } from 'rsvp';
+import { run } from '@ember/runloop';
 var session, user, adapter, app;
 
 import SessionService from 'torii/services/torii-session';
@@ -21,7 +23,7 @@ module('Session (open) - Integration', {
     session = lookup(app, 'service:session');
   },
   afterEach() {
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
@@ -42,14 +44,14 @@ test("starting auth sets isOpening to true", function(assert){
   };
 
   app.register("torii-adapter:dummy-success", DummyAdapter);
-  Ember.run(function(){
+  run(function(){
     session.open('dummy-success');
   });
 });
 
 test("successful auth sets isAuthenticated to true", function(assert){
   app.register("torii-adapter:dummy-success", DummyAdapter);
-  Ember.run(function(){
+  run(function(){
     session.open('dummy-success').then(function(){
       assert.ok(!session.get('isOpening'), 'session is no longer opening');
       assert.ok(session.get('isAuthenticated'), 'session is authenticated');
@@ -58,7 +60,7 @@ test("successful auth sets isAuthenticated to true", function(assert){
 });
 
 test("failed auth sets isAuthenticated to false, sets error", function(assert){
-  Ember.run(function(){
+  run(function(){
     session.open('dummy-failure').then(function(){
       assert.ok(false, 'should not resolve promise');
     }, function(){
@@ -85,7 +87,7 @@ module('Session (close) - Integration', {
     session.get('stateMachine').send('finishOpen', { currentUser: user});
   },
   afterEach() {
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
@@ -98,20 +100,20 @@ test("starting close sets isWorking to true", function(assert){
   adapter.close = function(){
     assert.ok(true, 'calls adapter.close');
     assert.ok(session.get('isWorking'), 'session.isWorking is true');
-    return Ember.RSVP.resolve();
+    return resolve();
   };
 
-  Ember.run(function(){
+  run(function(){
     session.close();
   });
 });
 
 test("finished close sets isWorking to false, isAuthenticated false", function(assert){
   adapter.close = function(){
-    return Ember.RSVP.resolve();
+    return resolve();
   };
 
-  Ember.run(function(){
+  run(function(){
     session.close().then(function(){
       assert.ok(!session.get('isWorking'), "isWorking is false");
       assert.ok(!session.get('isAuthenticated'), "isAuthenticated is false");
@@ -126,10 +128,10 @@ test("failed close sets isWorking to false, isAuthenticated true, error", functi
   var error = 'Oh my';
 
   adapter.close = function(){
-    return Ember.RSVP.reject(error);
+    return reject(error);
   };
 
-  Ember.run(function(){
+  run(function(){
     session.close().then(function(){
       assert.ok(false, "promise resolved");
     },function(error){

--- a/tests/integration/torii-test.js
+++ b/tests/integration/torii-test.js
@@ -1,3 +1,5 @@
+import { Promise as EmberPromise } from 'rsvp';
+import { run } from '@ember/runloop';
 var torii, app;
 
 import DummySuccessProvider from '../helpers/dummy-success-provider';
@@ -16,12 +18,12 @@ module('Torii - Integration', {
     torii = lookup(app, 'service:torii');
   },
   afterEach() {
-    Ember.run(app, 'destroy');
+    run(app, 'destroy');
   }
 });
 
 test("torii opens a dummy-success provider", function(assert){
-  Ember.run(function(){
+  run(function(){
     torii.open('dummy-success', {name: 'dummy'}).then(function(authentication){
       assert.ok(true, 'torii resolves an open promise');
       assert.equal(authentication.name, 'dummy', 'resolves with an authentication object');
@@ -32,7 +34,7 @@ test("torii opens a dummy-success provider", function(assert){
 });
 
 test("torii fails to open a dummy-failure provider", function(assert){
-  Ember.run(function(){
+  run(function(){
     torii.open('dummy-failure').then(function(){
       assert.ok(false, 'torii resolved an open promise');
     }, function(){
@@ -43,9 +45,9 @@ test("torii fails to open a dummy-failure provider", function(assert){
 
 test("torii fetches a dummy-success provider", function(assert){
   app.register('torii-provider:with-fetch', DummySuccessProvider.extend({
-    fetch: Ember.RSVP.Promise.resolve
+    fetch: EmberPromise.resolve
   }));
-  Ember.run(function(){
+  run(function(){
     torii.open('with-fetch', {name: 'dummy'}).then(function(){
       assert.ok(true, 'torii resolves a fetch promise');
     }, function(){
@@ -56,9 +58,9 @@ test("torii fetches a dummy-success provider", function(assert){
 
 test("torii fails to fetch a dummy-failure provider", function(assert){
   app.register('torii-provider:with-fetch', DummyFailureProvider.extend({
-    fetch: Ember.RSVP.Promise.reject
+    fetch: EmberPromise.reject
   }));
-  Ember.run(function(){
+  run(function(){
     torii.open('with-fetch').then(function(){
       assert.ok(false, 'torii resolve a fetch promise');
     }, function(){
@@ -69,9 +71,9 @@ test("torii fails to fetch a dummy-failure provider", function(assert){
 
 test("torii closes a dummy-success provider", function(assert){
   app.register('torii-provider:with-close', DummySuccessProvider.extend({
-    fetch: Ember.RSVP.Promise.resolve
+    fetch: EmberPromise.resolve
   }));
-  Ember.run(function(){
+  run(function(){
     torii.open('with-close', {name: 'dummy'}).then(function(){
       assert.ok(true, 'torii resolves a clos promise');
     }, function(){
@@ -82,9 +84,9 @@ test("torii closes a dummy-success provider", function(assert){
 
 test("torii fails to close a dummy-failure provider", function(assert){
   app.register('torii-provider:with-close', DummyFailureProvider.extend({
-    fetch: Ember.RSVP.Promise.reject
+    fetch: EmberPromise.reject
   }));
-  Ember.run(function(){
+  run(function(){
     torii.open('with-close').then(function(){
       assert.ok(false, 'torii resolves a close promise');
     }, function(){
@@ -124,7 +126,7 @@ test('raises when calling undefined #open', function(assert){
 test('fails silently when calling undefined #fetch', function(assert){
   var thrown = false, fetched;
   try {
-    Ember.run(function(){
+    run(function(){
       torii.fetch('dummy-failure').then(function(){
         fetched = true;
       });
@@ -139,7 +141,7 @@ test('fails silently when calling undefined #fetch', function(assert){
 test('fails silently when calling undefined #close', function(assert){
   var thrown = false, closed;
   try {
-    Ember.run(function(){
+    run(function(){
       torii.close('dummy-failure').then(function(){
         closed = true;
       });

--- a/tests/unit/adapters/dummy-test.js
+++ b/tests/unit/adapters/dummy-test.js
@@ -1,3 +1,5 @@
+import { get } from '@ember/object';
+import { run } from '@ember/runloop';
 import DummyAdapter from '../../helpers/dummy-adapter';
 import QUnit from 'qunit';
 let { module, test } = QUnit;
@@ -9,15 +11,15 @@ module("DummyAdapter - Unit", {
     adapter = DummyAdapter.create();
   },
   afterEach() {
-    Ember.run(adapter, 'destroy');
+    run(adapter, 'destroy');
   }
 });
 
 test("open resolves with a user", function(assert){
-  Ember.run(function(){
+  run(function(){
     adapter.open().then(function(data){
       assert.ok(true, 'resolved');
-      assert.ok(Ember.get(data,'currentUser.email'), 'dummy user has email');
+      assert.ok(get(data,'currentUser.email'), 'dummy user has email');
     });
   });
 });

--- a/tests/unit/configuration-test.js
+++ b/tests/unit/configuration-test.js
@@ -1,9 +1,11 @@
+import { run } from '@ember/runloop';
+import EmberObject from '@ember/object';
 import { configurable, configure } from 'torii/configuration';
 import QUnit from 'qunit';
 
 let { module, test } = QUnit;
 
-var Testable = Ember.Object.extend({
+var Testable = EmberObject.extend({
       name: 'test',
       required: configurable('apiKey'),
       defaulted: configurable('scope', 'email'),
@@ -19,7 +21,7 @@ module('Configuration - Unit', {
     testable = Testable.create();
   },
   afterEach() {
-    Ember.run(testable, 'destroy');
+    run(testable, 'destroy');
   }
 });
 

--- a/tests/unit/lib/query-string-test.js
+++ b/tests/unit/lib/query-string-test.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
+import EmberObject from '@ember/object';
 import QueryString from 'torii/lib/query-string';
 import QUnit from 'qunit';
 
@@ -13,7 +14,7 @@ var obj,
 
 module('QueryString - Unit', {
   beforeEach() {
-    obj = Ember.Object.create({
+    obj = EmberObject.create({
       clientId:         clientId,
       responseType:     responseType,
       redirectUri:      redirectUri,
@@ -23,7 +24,7 @@ module('QueryString - Unit', {
     });
   },
   afterEach() {
-    Ember.run(obj, 'destroy');
+    run(obj, 'destroy');
   }
 });
 

--- a/tests/unit/providers/azure-ad-oauth2-test.js
+++ b/tests/unit/providers/azure-ad-oauth2-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 import { getConfiguration, configure } from 'torii/configuration';
 import AzureAdProvider from 'torii/providers/azure-ad-oauth2';
 import QUnit from 'qunit';
@@ -18,7 +19,7 @@ module('Unit - AzureAdOAuth2Provider', {
     provider = AzureAdProvider.create();
   },
   afterEach() {
-    Ember.run(provider, 'destroy');
+    run(provider, 'destroy');
     configure(originalConfiguration);
   }
 });

--- a/tests/unit/providers/dummy-failure-test.js
+++ b/tests/unit/providers/dummy-failure-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 var provider;
 
 import Provider from '../../helpers/dummy-failure-provider';
@@ -10,12 +11,12 @@ module('DummyFailureProvider - Unit', {
     provider = Provider.create();
   },
   afterEach() {
-    Ember.run(provider, 'destroy');
+    run(provider, 'destroy');
   }
 });
 
 test("Provider rejects on open", function(assert){
-  Ember.run(function(){
+  run(function(){
     provider.open().then(function(){
       assert.ok(false, 'dummy-success fulfilled an open promise');
     }, function(){

--- a/tests/unit/providers/dummy-success-test.js
+++ b/tests/unit/providers/dummy-success-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 var provider;
 
 import Provider from '../../helpers/dummy-success-provider';
@@ -10,12 +11,12 @@ module('DummySuccessProvider - Unit', {
     provider = Provider.create();
   },
   afterEach() {
-    Ember.run(provider, 'destroy');
+    run(provider, 'destroy');
   }
 });
 
 test("Provider fulfills on open", function(assert){
-  Ember.run(function(){
+  run(function(){
     provider.open().then(function(){
       assert.ok(true, 'dummy-success resolves an open promise');
     }, function(){

--- a/tests/unit/providers/edmodo-connect-test.js
+++ b/tests/unit/providers/edmodo-connect-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 var provider;
 
 import { getConfiguration, configure } from 'torii/configuration';
@@ -19,7 +20,7 @@ module('Unit - EdmodoConnectProvider', {
     provider = EdmodoConnectProvider.create();
   },
   afterEach() {
-    Ember.run(provider, 'destroy');
+    run(provider, 'destroy');
     configure(originalConfiguration);
   }
 });

--- a/tests/unit/providers/google-oauth2-bearer-test.js
+++ b/tests/unit/providers/google-oauth2-bearer-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 var provider;
 
 import { getConfiguration, configure } from 'torii/configuration';
@@ -19,7 +20,7 @@ module('Unit - GoogleAuth2BearerProvider', {
     provider = GoogleBearerProvider.create();
   },
   afterEach() {
-    Ember.run(provider, 'destroy');
+    run(provider, 'destroy');
     configure(originalConfiguration);
   }
 });

--- a/tests/unit/providers/google-oauth2-test.js
+++ b/tests/unit/providers/google-oauth2-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 import { getConfiguration, configure } from 'torii/configuration';
 
 import GoogleProvider from 'torii/providers/google-oauth2';
@@ -18,7 +19,7 @@ module('Unit - GoogleAuth2Provider', {
     provider = GoogleProvider.create();
   },
   afterEach() {
-    Ember.run(provider, 'destroy');
+    run(provider, 'destroy');
     configure(originalConfiguration);
   }
 });

--- a/tests/unit/providers/oauth1-test.js
+++ b/tests/unit/providers/oauth1-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 import { getConfiguration, configure } from 'torii/configuration';
 
 import QUnit from 'qunit';
@@ -27,7 +28,7 @@ module('MockOauth1Provider (oauth1 subclass) - Unit', {
     provider = Provider.create();
   },
   afterEach() {
-    Ember.run(provider, 'destroy');
+    run(provider, 'destroy');
     configure(originalConfiguration);
   }
 });

--- a/tests/unit/providers/oauth2-bearer-test.js
+++ b/tests/unit/providers/oauth2-bearer-test.js
@@ -1,3 +1,5 @@
+import { resolve } from 'rsvp';
+import { run } from '@ember/runloop';
 import { getConfiguration, configure } from 'torii/configuration';
 
 import BaseProvider from 'torii/providers/oauth2-bearer';
@@ -25,7 +27,7 @@ module('MockOauth2Provider (oauth2-bearer subclass) - Unit', {
     provider = Provider.create();
   },
   afterEach() {
-    Ember.run(provider, 'destroy');
+    run(provider, 'destroy');
     configure(originalConfiguration);
   }
 });
@@ -85,13 +87,13 @@ test('Provider#open assert.throws when any required response params are missing'
     open: function(/*url, responseParams*/){
       assert.ok(true, 'calls popup.open');
 
-      return Ember.RSVP.resolve({state: 'state'});
+      return resolve({state: 'state'});
     }
   };
 
   provider.set('popup', mockPopup);
 
-  Ember.run(function(){
+  run(function(){
     provider.open().then(function(){
       assert.ok(false, '#open should not resolve');
     }).catch(function(e){

--- a/tests/unit/providers/oauth2-code-test.js
+++ b/tests/unit/providers/oauth2-code-test.js
@@ -1,3 +1,5 @@
+import { resolve } from 'rsvp';
+import { run } from '@ember/runloop';
 import { getConfiguration, configure } from 'torii/configuration';
 import BaseProvider from 'torii/providers/oauth2-code';
 import QUnit from 'qunit';
@@ -35,7 +37,7 @@ module('MockOauth2Provider (oauth2-code subclass) - Unit', {
     tokenProvider = TokenProvider.create();
   },
   afterEach() {
-    Ember.run(provider, 'destroy');
+    run(provider, 'destroy');
     configure(originalConfiguration);
   }
 });
@@ -97,13 +99,13 @@ test('Provider#open assert.throws when any required response params are missing'
     open: function(/*url, responseParams*/){
       assert.ok(true, 'calls popup.open');
 
-      return Ember.RSVP.resolve({state: 'state'});
+      return resolve({state: 'state'});
     }
   };
 
   provider.set('popup', mockPopup);
 
-  Ember.run(function(){
+  run(function(){
     provider.open().then(function(){
       assert.ok(false, '#open should not resolve');
     }).catch(function(e){
@@ -130,13 +132,13 @@ test('should use the value of provider.responseType as key for the authorization
   var mockPopup = {
     open: function(/*url, responseParams*/){
       assert.ok(true, 'calls popup.open');
-      return Ember.RSVP.resolve({ 'token_id': 'test', 'authorization_code': 'pief', 'state': 'test-state' });
+      return resolve({ 'token_id': 'test', 'authorization_code': 'pief', 'state': 'test-state' });
     }
   };
 
   tokenProvider.set('popup', mockPopup);
 
-  Ember.run(function(){
+  run(function(){
     tokenProvider.open().then(function(res){
       assert.ok(res.authorizationCode === 'test', 'authenticationToken present');
     });
@@ -191,7 +193,7 @@ test('URI-decodes the authorization code', function(assert){
 
   var mockPopup = {
     open: function(/*url, responseParams*/){
-      return Ember.RSVP.resolve({
+      return resolve({
         'token_id': encodeURIComponent('test=='),
         'authorization_code': 'pief',
         'state': 'test-state'
@@ -201,7 +203,7 @@ test('URI-decodes the authorization code', function(assert){
 
   tokenProvider.set('popup', mockPopup);
 
-  Ember.run(function(){
+  run(function(){
     tokenProvider.open().then(function(res){
       assert.equal(res.authorizationCode, 'test==', 'authorizationCode decoded');
     });

--- a/tests/unit/providers/stripe-connect-test.js
+++ b/tests/unit/providers/stripe-connect-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 import { getConfiguration, configure } from 'torii/configuration';
 import StripeConnectProvider from 'torii/providers/stripe-connect';
 import QUnit from 'qunit';
@@ -18,7 +19,7 @@ module('Unit - StripeConnectProvider', {
     provider = StripeConnectProvider.create();
   },
   afterEach() {
-    Ember.run(provider, 'destroy');
+    run(provider, 'destroy');
     configure(originalConfiguration);
   }
 });

--- a/tests/unit/redirect-handler-test.js
+++ b/tests/unit/redirect-handler-test.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 import RedirectHandler from 'torii/redirect-handler';
 import { CURRENT_REQUEST_KEY } from 'torii/mixins/ui-service-mixin';
 import QUnit from 'qunit';
@@ -46,7 +47,7 @@ test("handles a tori-popup window with a current request key in localStorage and
   };
   var handler = RedirectHandler.create({windowObject: mockWindow});
 
-  Ember.run(function(){
+  run(function(){
     handler.run().then(function(){}, function(){
       assert.ok(false, "run handler rejected a basic url");
     });
@@ -60,7 +61,7 @@ test('rejects the promise if there is no request key', function(assert){
   var mockWindow = buildMockWindow("", "http://authServer?code=1234512345fw");
   var handler = RedirectHandler.create({windowObject: mockWindow});
 
-  Ember.run(function(){
+  run(function(){
     handler.run().then(function(){
       assert.ok(false, "run handler succeeded on a url");
     }, function(){
@@ -78,7 +79,7 @@ test('does not set local storage when not a torii popup', function(assert){
 
   var handler = RedirectHandler.create({windowObject: mockWindow});
 
-  Ember.run(function(){
+  run(function(){
     handler.run().then(function(){
       assert.ok(false, "run handler succeeded on a popup");
     }, function(){
@@ -103,7 +104,7 @@ test('closes the window when a torii popup with request', function(assert){
     assert.ok(true, "Window was closed");
   };
 
-  Ember.run(function(){
+  run(function(){
     handler.run();
   });
 });
@@ -119,7 +120,7 @@ test('does not close the window when a not torii popup', function(assert){
     assert.ok(false, "Window was closed unexpectedly");
   };
 
-  Ember.run(function(){
+  run(function(){
     handler.run().then(function(){}, function(){
       assert.ok(true, "error handler is called");
     });

--- a/tests/unit/routing/application-route-mixin-test.js
+++ b/tests/unit/routing/application-route-mixin-test.js
@@ -1,3 +1,6 @@
+import { later } from '@ember/runloop';
+import { Promise as EmberPromise, reject } from 'rsvp';
+import Route from '@ember/routing/route';
 import ApplicationRouteMixin from 'torii/routing/application-route-mixin';
 import QUnit from 'qunit';
 import { configure, getConfiguration } from 'torii/configuration';
@@ -20,7 +23,7 @@ module('Application Route Mixin - Unit', {
 test("beforeModel calls checkLogin after _super#beforeModel", function(assert){
   var route;
   var callOrder = [];
-  route = Ember.Route
+  route = Route
     .extend({
       beforeModel: function() {
         callOrder.push('super');
@@ -41,11 +44,11 @@ test("beforeModel calls checkLogin after _super#beforeModel", function(assert){
 test("beforeModel calls checkLogin after promise from _super#beforeModel is resolved", function(assert){
   var route;
   var callOrder = [];
-  route = Ember.Route
+  route = Route
     .extend({
       beforeModel: function() {
-        return new Ember.RSVP.Promise(function(resolve){
-          Ember.run.later(function(){
+        return new EmberPromise(function(resolve){
+          later(function(){
             callOrder.push('super');
             resolve();
           }, 20);
@@ -69,11 +72,11 @@ test('checkLogic fails silently when no session is available', function(assert){
   assert.expect(2);
 
   var fetchCalled = false;
-  var route = Ember.Route.extend(ApplicationRouteMixin, {
+  var route = Route.extend(ApplicationRouteMixin, {
     session: {
       fetch: function() {
         fetchCalled = true;
-        return Ember.RSVP.reject('no session is available');
+        return reject('no session is available');
       }
     }
   }).create();

--- a/tests/unit/routing/authenticated-route-mixin-test.js
+++ b/tests/unit/routing/authenticated-route-mixin-test.js
@@ -1,3 +1,11 @@
+import EmberRouter from '@ember/routing/router';
+import { later } from '@ember/runloop';
+import {
+  Promise as EmberPromise,
+  resolve,
+  reject
+} from 'rsvp';
+import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'torii/routing/authenticated-route-mixin';
 import QUnit from 'qunit';
 import { configure, getConfiguration } from 'torii/configuration';
@@ -20,7 +28,7 @@ module('Authenticated Route Mixin - Unit', {
 test("beforeModel calls authenicate after _super#beforeModel", function(assert){
   var route;
   var callOrder = [];
-  route = Ember.Route
+  route = Route
     .extend({
       beforeModel: function() {
         callOrder.push('super');
@@ -41,11 +49,11 @@ test("beforeModel calls authenicate after _super#beforeModel", function(assert){
 test("route respects beforeModel super priority when promise is returned", function(assert){
   var route;
   var callOrder = [];
-  route = Ember.Route
+  route = Route
     .extend({
       beforeModel: function() {
-        return new Ember.RSVP.Promise(function(resolve){
-          Ember.run.later(function(){
+        return new EmberPromise(function(resolve){
+          later(function(){
             callOrder.push('super');
             resolve();
           }, 20);
@@ -87,7 +95,7 @@ test('attempting authentication calls fetchDefaultProvider', function(assert){
       isAuthenticated: undefined,
       fetch: function(){
         fetchCalled = true;
-        return Ember.RSVP.resolve();
+        return resolve();
       }
     }
   });
@@ -106,7 +114,7 @@ test('failed authentication calls accessDenied', function(assert){
       isAuthenticated: undefined,
       fetch: function(){
         fetchCalled = true;
-        return Ember.RSVP.reject();
+        return reject();
       }
     },
     accessDenied: function() {
@@ -129,7 +137,7 @@ test('failed authentication causes accessDenied action to be sent', function(ass
       isAuthenticated: undefined,
       fetch: function(){
         fetchCalled = true;
-        return Ember.RSVP.reject();
+        return reject();
       }
     }
   });
@@ -157,7 +165,7 @@ test('failed authentication causes accessDenied action to be sent with transitio
       isAuthenticated: undefined,
       fetch: function(){
         fetchCalled = true;
-        return Ember.RSVP.reject();
+        return reject();
       }
     },
     
@@ -173,5 +181,5 @@ test('failed authentication causes accessDenied action to be sent with transitio
 });
 
 function createAuthenticatedRoute(attrs) {
-  return Ember.Router.extend(AuthenticatedRouteMixin, attrs).create();
+  return EmberRouter.extend(AuthenticatedRouteMixin, attrs).create();
 }

--- a/tests/unit/services/popup-test.js
+++ b/tests/unit/services/popup-test.js
@@ -1,3 +1,5 @@
+import { run } from '@ember/runloop';
+import $ from 'jquery';
 import Popup from 'torii/services/popup';
 import PopupIdSerializer from 'torii/lib/popup-id-serializer';
 import { CURRENT_REQUEST_KEY } from "torii/mixins/ui-service-mixin";
@@ -26,7 +28,7 @@ var buildPopupIdGenerator = function(popupId){
 };
 
 var buildMockStorageEvent = function(popupId, redirectUrl){
-  return Ember.$.Event('storage', {
+  return $.Event('storage', {
     originalEvent: {
       key: PopupIdSerializer.serialize(popupId),
       newValue: redirectUrl
@@ -42,7 +44,7 @@ module("Popup - Unit", {
   afterEach() {
     localStorage.removeItem(CURRENT_REQUEST_KEY);
     window.open = originalWindowOpen;
-    Ember.run(popup, 'destroy');
+    run(popup, 'destroy');
   }
 });
 
@@ -68,7 +70,7 @@ test("open resolves based on popup window", function(assert){
     return mockWindow;
   };
 
-  Ember.run(function(){
+  run(function(){
     popup.open(expectedUrl, ['code']).then(function(data){
       assert.ok(true, 'resolves promise');
       assert.equal(popupId, PopupIdSerializer.deserialize(mockWindow.name), "sets the window's name properly");
@@ -87,7 +89,7 @@ test("open resolves based on popup window", function(assert){
 
   localStorage.setItem(PopupIdSerializer.serialize(popupId), redirectUrl);
   // Need to manually trigger storage event, since it doesn't fire in the current window
-  Ember.$(window).trigger(buildMockStorageEvent(popupId, redirectUrl));
+  $(window).trigger(buildMockStorageEvent(popupId, redirectUrl));
 });
 
 test("open rejects when window does not open", function(assert){
@@ -99,7 +101,7 @@ test("open rejects when window does not open", function(assert){
     return closedWindow;
   };
 
-  Ember.run(function(){
+  run(function(){
     popup.open('http://some-url.com', ['code']).then(function(){
       assert.ok(false, 'resolves promise');
     }, function(){
@@ -117,7 +119,7 @@ test("open does not resolve when receiving a storage event for the wrong popup i
     return buildMockWindow();
   };
 
-  var promise = Ember.run(function(){
+  var promise = run(function(){
     return popup.open('http://someserver.com', ['code']).then(function(){
       assert.ok(false, 'resolves the open promise');
     }, function(){
@@ -127,7 +129,7 @@ test("open does not resolve when receiving a storage event for the wrong popup i
 
   localStorage.setItem(PopupIdSerializer.serialize("invalid"), "http://authServer");
   // Need to manually trigger storage event, since it doesn't fire in the current window
-  Ember.$(window).trigger(buildMockStorageEvent("invalid", "http://authServer"));
+  $(window).trigger(buildMockStorageEvent("invalid", "http://authServer"));
 
   setTimeout(function(){
     assert.ok(!promise.isFulfilled, 'promise is not fulfulled by invalid data');
@@ -147,7 +149,7 @@ test("open rejects when window closes", function(assert){
     return mockWindow;
   };
 
-  Ember.run(function(){
+  run(function(){
     popup.open('some-url', ['code']).then(function(){
       assert.ok(false, 'resolved the open promise');
     }, function(){
@@ -165,7 +167,7 @@ test("localStorage state is cleaned up when parent window closes", function(asse
     return mockWindow;
   };
 
-  Ember.run(function(){
+  run(function(){
     popup.open('some-url', ['code']).then(function(){
       assert.ok(false, 'resolved the open promise');
     }, function(){

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,7 +1775,7 @@ electron-to-chromium@^1.3.17:
   version "1.3.17"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.17.tgz#41c13457cc7166c5c15e767ae61d86a8cacdee5d"
 
-ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.3.0:
+ember-cli-babel@^6.0.0-beta.7:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.7.1.tgz#98de75cb3eaf3198a80aac36ae82d8ea48c9d91f"
   dependencies:
@@ -1792,7 +1792,7 @@ ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.3.0:
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-cli-babel@^6.8.1:
+ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,88 +2,15 @@
 # yarn lockfile v1
 
 
-"@glimmer/compiler@^0.25.3":
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.25.3.tgz#25eb06394f3ba1c1fae5af25c9cf7deb2c11ef4e"
-  dependencies:
-    "@glimmer/interfaces" "^0.25.3"
-    "@glimmer/syntax" "^0.25.3"
-    "@glimmer/util" "^0.25.3"
-    "@glimmer/wire-format" "^0.25.3"
-    simple-html-tokenizer "^0.3.0"
-
 "@glimmer/di@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
-
-"@glimmer/interfaces@^0.25.3":
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.25.3.tgz#8c460b28ad5a17eaa1712e6aa7b8ebb49738c38f"
-  dependencies:
-    "@glimmer/wire-format" "^0.25.3"
-
-"@glimmer/node@^0.25.3":
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.25.3.tgz#301828e8455be141d5384b01980ed9be02984059"
-  dependencies:
-    "@glimmer/runtime" "^0.25.3"
-    simple-dom "^0.3.0"
-
-"@glimmer/object-reference@^0.25.3":
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/object-reference/-/object-reference-0.25.3.tgz#e0d1fa874f912e7d1232d487fcd2096e6b31b620"
-  dependencies:
-    "@glimmer/reference" "^0.25.3"
-    "@glimmer/util" "^0.25.3"
-
-"@glimmer/object@^0.25.3":
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/object/-/object-0.25.3.tgz#451eb208dadba1ede9c0c038a90dfe32637493fe"
-  dependencies:
-    "@glimmer/object-reference" "^0.25.3"
-    "@glimmer/util" "^0.25.3"
-
-"@glimmer/reference@^0.25.3":
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.25.3.tgz#a09ddc397bee0223de73ea5044a304a30935104f"
-  dependencies:
-    "@glimmer/util" "^0.25.3"
 
 "@glimmer/resolver@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.4.1.tgz#cd9644572c556e7e799de1cf8eff2b999cf5b878"
   dependencies:
     "@glimmer/di" "^0.2.0"
-
-"@glimmer/runtime@^0.25.3":
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.25.3.tgz#ae2101a1e4de3330d08f20806c18327dbfa86d78"
-  dependencies:
-    "@glimmer/interfaces" "^0.25.3"
-    "@glimmer/object" "^0.25.3"
-    "@glimmer/object-reference" "^0.25.3"
-    "@glimmer/reference" "^0.25.3"
-    "@glimmer/util" "^0.25.3"
-    "@glimmer/wire-format" "^0.25.3"
-
-"@glimmer/syntax@^0.25.3":
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.25.3.tgz#b3f8a59bee616fd600301d778de3b649bf77036e"
-  dependencies:
-    "@glimmer/interfaces" "^0.25.3"
-    "@glimmer/util" "^0.25.3"
-    handlebars "^4.0.6"
-    simple-html-tokenizer "^0.3.0"
-
-"@glimmer/util@^0.25.3":
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.25.3.tgz#7cedf72947137b519658c8be34d0d5965cebe3a1"
-
-"@glimmer/wire-format@^0.25.3":
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.25.3.tgz#046692b3a26a30a498712266cd0bdb47d7710f37"
-  dependencies:
-    "@glimmer/util" "^0.25.3"
 
 abbrev@1:
   version "1.1.0"
@@ -151,6 +78,12 @@ amd-name-resolver@0.0.6:
 amd-name-resolver@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz#814301adfe8a2f109f6e84d5e935196efb669615"
+  dependencies:
+    ensure-posix-path "^1.0.1"
+
+amd-name-resolver@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.0.0.tgz#0e593b28d6fa3326ab1798107edaea961046e8d8"
   dependencies:
     ensure-posix-path "^1.0.1"
 
@@ -1064,6 +997,17 @@ broccoli-debug@^0.6.1, broccoli-debug@^0.6.2:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
+broccoli-debug@^0.6.3:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.4.tgz#986eb3d2005e00e3bb91f9d0a10ab137210cd150"
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    symlink-or-copy "^1.1.8"
+    tree-sync "^1.2.2"
+
 broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.2.4.tgz#409afb94b9a3a6da9fac8134e91e205f40cc7330"
@@ -1082,7 +1026,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -1248,19 +1192,19 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.0"
 
-broccoli-uglify-sourcemap@^1.0.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-1.5.2.tgz#04f84ab0db539031fa868ccfa563c9932d50cedb"
+broccoli-uglify-sourcemap@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.0.1.tgz#e8f2f6c49e04b6e921f1ecd30e12f06fb75e585f"
   dependencies:
     broccoli-plugin "^1.2.1"
-    debug "^2.2.0"
-    lodash.merge "^4.5.1"
-    matcher-collection "^1.0.0"
+    debug "^3.1.0"
+    lodash.defaultsdeep "^4.6.0"
+    matcher-collection "^1.0.5"
     mkdirp "^0.5.0"
-    source-map-url "^0.3.0"
+    source-map-url "^0.4.0"
     symlink-or-copy "^1.0.1"
-    uglify-js "^2.7.0"
-    walk-sync "^0.1.3"
+    uglify-es "^3.1.3"
+    walk-sync "^0.3.2"
 
 browserslist@^2.1.2:
   version "2.3.0"
@@ -1373,6 +1317,14 @@ chalk@^2.0.0, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chalk@^2.0.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 charm@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/charm/-/charm-1.0.2.tgz#8add367153a6d9a581331052c4090991da995e35"
@@ -1417,7 +1369,7 @@ clean-css@^3.4.5:
     commander "2.8.x"
     source-map "0.4.x"
 
-cli-cursor@^1.0.1, cli-cursor@^1.0.2:
+cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
@@ -1429,9 +1381,9 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-spinners@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+cli-spinners@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.1.0.tgz#f1847b168844d917a671eb9d147e3df497c90d06"
 
 cli-table2@^0.2.0:
   version "0.2.0"
@@ -1512,6 +1464,10 @@ commander@^2.6.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
+commander@~2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.1.tgz#468635c4168d06145b9323356d1da84d14ac4a7a"
+
 component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
@@ -1573,13 +1529,13 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-console-ui@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/console-ui/-/console-ui-1.0.3.tgz#31c524461b63422769f9e89c173495d91393721c"
+console-ui@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/console-ui/-/console-ui-2.0.1.tgz#56d0721ebcc44e6c9c3de02f355f898aba41ea79"
   dependencies:
-    chalk "^1.1.3"
-    inquirer "^1.2.3"
-    ora "^0.2.0"
+    chalk "^2.1.0"
+    inquirer "^2"
+    ora "^1.3.0"
     through "^2.3.8"
 
 consolidate@^0.14.0:
@@ -1684,6 +1640,12 @@ debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.
   dependencies:
     ms "2.0.0"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1691,10 +1653,6 @@ decamelize@^1.0.0:
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
-
-deep-freeze@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/deep-freeze/-/deep-freeze-0.0.1.tgz#3a0b0005de18672819dfd38cd31f91179c893e84"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -1893,9 +1851,13 @@ ember-cli-legacy-blueprints@^0.1.2:
     rsvp "^3.0.17"
     silent-error "^1.0.0"
 
-ember-cli-lodash-subset@^1.0.11, ember-cli-lodash-subset@^1.0.7:
+ember-cli-lodash-subset@^1.0.7:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz#af2e77eba5dcb0d77f3308d3a6fd7d3450f6e537"
+
+ember-cli-lodash-subset@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
 
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"
@@ -1965,11 +1927,12 @@ ember-cli-test-loader@^2.2.0:
   dependencies:
     ember-cli-babel "^6.8.1"
 
-ember-cli-uglify@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-uglify/-/ember-cli-uglify-1.2.0.tgz#3208c32b54bc2783056e8bb0d5cfe9bbaf17ffb2"
+ember-cli-uglify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-uglify/-/ember-cli-uglify-2.0.0.tgz#b096727d7d1718acc9bfe5d1bc81ce26cafdf6ca"
   dependencies:
-    broccoli-uglify-sourcemap "^1.0.0"
+    broccoli-uglify-sourcemap "^2.0.0"
+    lodash.defaultsdeep "^4.6.0"
 
 ember-cli-valid-component-name@^1.0.0:
   version "1.0.0"
@@ -1990,11 +1953,11 @@ ember-cli-version-checker@^2.0.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
-ember-cli@~2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.15.0.tgz#4f282f85f0858dc96ed526e5f4724502c74fe26e"
+ember-cli@~2.16.2:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.16.2.tgz#53b922073a8e6f34255a6e0dcb1794a91ba3e1b7"
   dependencies:
-    amd-name-resolver "0.0.7"
+    amd-name-resolver "1.0.0"
     babel-plugin-transform-es2015-modules-amd "^6.24.0"
     bower-config "^1.3.0"
     bower-endpoint-parser "0.2.2"
@@ -2004,7 +1967,8 @@ ember-cli@~2.15.0:
     broccoli-concat "^3.2.2"
     broccoli-config-loader "^1.0.0"
     broccoli-config-replace "^1.1.2"
-    broccoli-funnel "^1.0.6"
+    broccoli-debug "^0.6.3"
+    broccoli-funnel "^2.0.0"
     broccoli-funnel-reducer "^1.0.0"
     broccoli-merge-trees "^2.0.0"
     broccoli-middleware "^1.0.0"
@@ -2012,31 +1976,30 @@ ember-cli@~2.15.0:
     broccoli-stew "^1.2.0"
     calculate-cache-key-for-tree "^1.0.0"
     capture-exit "^1.1.0"
-    chalk "^1.1.3"
+    chalk "^2.0.1"
     clean-base-url "^1.0.0"
     compression "^1.4.4"
     configstore "^3.0.0"
-    console-ui "^1.0.2"
+    console-ui "^2.0.0"
     core-object "^3.1.3"
     dag-map "^2.0.2"
-    deep-freeze "^0.0.1"
     diff "^3.2.0"
     ember-cli-broccoli-sane-watcher "^2.0.4"
     ember-cli-is-package-missing "^1.0.0"
     ember-cli-legacy-blueprints "^0.1.2"
-    ember-cli-lodash-subset "^1.0.11"
+    ember-cli-lodash-subset "^2.0.1"
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-preprocess-registry "^3.1.0"
     ember-cli-string-utils "^1.0.0"
     ember-try "^0.2.15"
     ensure-posix-path "^1.0.2"
-    execa "^0.7.0"
+    execa "^0.8.0"
     exists-sync "0.0.4"
     exit "^0.1.2"
     express "^4.12.3"
     filesize "^3.1.3"
     find-up "^2.1.0"
-    fs-extra "^3.0.0"
+    fs-extra "^4.0.0"
     fs-tree-diff "^0.5.2"
     get-caller-file "^1.0.0"
     git-repo-info "^1.4.1"
@@ -2064,7 +2027,7 @@ ember-cli@~2.15.0:
     promise-map-series "^0.2.1"
     quick-temp "^0.1.8"
     resolve "^1.3.0"
-    rsvp "^3.3.3"
+    rsvp "^3.6.0"
     sane "^1.6.0"
     semver "^5.1.1"
     silent-error "^1.0.0"
@@ -2123,15 +2086,10 @@ ember-router-generator@^1.0.0, ember-router-generator@^1.2.3:
   dependencies:
     recast "^0.11.3"
 
-ember-source@~2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.15.0.tgz#901cbe3abee09292372b06f6aa8dd342683be2d5"
+ember-source@~2.16.0:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.16.2.tgz#ebc29ce36dec3ecc80f6b1b02218d63ca5041088"
   dependencies:
-    "@glimmer/compiler" "^0.25.3"
-    "@glimmer/node" "^0.25.3"
-    "@glimmer/reference" "^0.25.3"
-    "@glimmer/runtime" "^0.25.3"
-    "@glimmer/util" "^0.25.3"
     broccoli-funnel "^1.2.0"
     broccoli-merge-trees "^2.0.0"
     ember-cli-get-component-path-option "^1.0.0"
@@ -2143,12 +2101,10 @@ ember-source@~2.15.0:
     ember-cli-valid-component-name "^1.0.0"
     ember-cli-version-checker "^1.3.1"
     ember-router-generator "^1.2.3"
-    handlebars "^4.0.6"
+    fs-extra "^4.0.1"
+    inflection "^1.12.0"
     jquery "^3.2.1"
     resolve "^1.3.3"
-    rsvp "^3.6.1"
-    simple-dom "^0.3.0"
-    simple-html-tokenizer "^0.4.1"
 
 ember-test-helpers@^0.6.3:
   version "0.6.3"
@@ -2360,9 +2316,9 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.1.3"
 
-execa@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -2511,13 +2467,6 @@ fb-watchman@^2.0.0:
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
   dependencies:
     bser "^2.0.0"
-
-figures@^1.3.5:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
-  dependencies:
-    escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -2678,12 +2627,12 @@ fs-extra@^2.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
 
-fs-extra@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+fs-extra@^4.0.0, fs-extra@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
   dependencies:
     graceful-fs "^4.1.2"
-    jsonfile "^3.0.0"
+    jsonfile "^4.0.0"
     universalify "^0.1.0"
 
 fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6:
@@ -2850,7 +2799,7 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
-handlebars@^4.0.4, handlebars@^4.0.6:
+handlebars@^4.0.4:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.10.tgz#3d30c718b09a3d96f23ea4cc1f403c4d3ba9ff4f"
   dependencies:
@@ -3010,7 +2959,7 @@ indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
 
-inflection@^1.7.0, inflection@^1.7.1:
+inflection@^1.12.0, inflection@^1.7.0, inflection@^1.7.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
 
@@ -3039,22 +2988,22 @@ inline-source-map-comment@^1.0.5:
     sum-up "^1.0.1"
     xtend "^4.0.0"
 
-inquirer@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-1.2.3.tgz#4dec6f32f37ef7bb0b2ed3f1d1a5c3f545074918"
+inquirer@^2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-2.0.0.tgz#e1351687b90d150ca403ceaa3cefb1e3065bef4b"
   dependencies:
     ansi-escapes "^1.1.0"
     chalk "^1.0.0"
     cli-cursor "^1.0.1"
     cli-width "^2.0.0"
     external-editor "^1.1.0"
-    figures "^1.3.5"
+    figures "^2.0.0"
     lodash "^4.3.0"
     mute-stream "0.0.6"
     pinkie-promise "^2.0.0"
     run-async "^2.2.0"
     rx "^4.1.0"
-    string-width "^1.0.1"
+    string-width "^2.0.0"
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
@@ -3314,9 +3263,9 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonfile@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -3486,7 +3435,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.merge@^4.3.0, lodash.merge@^4.4.0, lodash.merge@^4.5.1, lodash.merge@^4.6.0:
+lodash.merge@^4.3.0, lodash.merge@^4.4.0, lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
@@ -3526,6 +3475,12 @@ lodash@^3.10.1:
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3579,6 +3534,12 @@ markdown-it@^8.3.0, markdown-it@^8.3.1:
 matcher-collection@^1.0.0, matcher-collection@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-1.0.4.tgz#2f66ae0869996f29e43d0b62c83dd1d43e581755"
+  dependencies:
+    minimatch "^3.0.2"
+
+matcher-collection@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-1.0.5.tgz#2ee095438372cb8884f058234138c05c644ec339"
   dependencies:
     minimatch "^3.0.2"
 
@@ -3901,14 +3862,14 @@ options@>=0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
 
-ora@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+ora@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-1.3.0.tgz#80078dd2b92a934af66a3ad72a5b910694ede51a"
   dependencies:
     chalk "^1.1.1"
-    cli-cursor "^1.0.2"
-    cli-spinners "^0.1.2"
-    object-assign "^4.0.1"
+    cli-cursor "^2.1.0"
+    cli-spinners "^1.0.0"
+    log-symbols "^1.0.2"
 
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
@@ -4341,7 +4302,7 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
-rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0, rsvp@^3.6.1:
+rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0, rsvp@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
@@ -4456,18 +4417,6 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0:
   dependencies:
     debug "^2.2.0"
 
-simple-dom@^0.3.0:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/simple-dom/-/simple-dom-0.3.2.tgz#0663d10f1556f1500551d518f56e3aba0871371d"
-
-simple-html-tokenizer@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz#9b8b5559d80e331a544dd13dd59382e5d0d94411"
-
-simple-html-tokenizer@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.4.1.tgz#028988bb7fe8b2e6645676d82052587d440b02d3"
-
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -4550,6 +4499,10 @@ source-map-url@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
 
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+
 source-map@0.4.x, source-map@^0.4.2, source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -4559,6 +4512,10 @@ source-map@0.4.x, source-map@^0.4.2, source-map@^0.4.4:
 source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spawn-args@^0.2.0:
   version "0.2.0"
@@ -4879,7 +4836,14 @@ uc.micro@^1.0.1, uc.micro@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
 
-uglify-js@^2.6, uglify-js@^2.7.0:
+uglify-es@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.2.0.tgz#fbbfb9dc465ec7e5065701b9720d0de977d0bc24"
+  dependencies:
+    commander "~2.12.1"
+    source-map "~0.6.1"
+
+uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
@@ -4972,10 +4936,6 @@ walk-sync@0.3.1:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
 
-walk-sync@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.1.3.tgz#8a07261a00bda6cfb1be25e9f100fad57546f583"
-
 walk-sync@^0.2.5, walk-sync@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.2.7.tgz#b49be4ee6867657aeb736978b56a29d10fa39969"
@@ -4983,7 +4943,7 @@ walk-sync@^0.2.5, walk-sync@^0.2.7:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
 
-walk-sync@^0.3.0, walk-sync@^0.3.1:
+walk-sync@^0.3.0, walk-sync@^0.3.1, walk-sync@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.2.tgz#4827280afc42d0e035367c4a4e31eeac0d136f75"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,6 +2209,14 @@ escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+eslint-plugin-ember@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-5.0.1.tgz#bd4b20e137b01530b709d87feb8428bbd68eb096"
+  dependencies:
+    ember-rfc176-data "^0.2.7"
+    require-folder-tree "^1.4.5"
+    snake-case "^2.1.0"
+
 eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
@@ -3468,6 +3476,10 @@ lodash.uniqby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
 
+lodash@3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.8.0.tgz#376eb98bdcd9382a9365c33c4cb8250de1325b91"
+
 lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -3491,6 +3503,10 @@ loose-envify@^1.0.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+lower-case@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
 
 lru-cache@^4.0.1:
   version "4.1.1"
@@ -3707,6 +3723,12 @@ natural-compare@^1.4.0:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+no-case@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
+  dependencies:
+    lower-case "^1.1.1"
 
 node-fetch@^1.3.3:
   version "1.7.1"
@@ -4238,6 +4260,12 @@ request@^2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
+require-folder-tree@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/require-folder-tree/-/require-folder-tree-1.4.5.tgz#dfe553cbab98cc88e1c56a3f2f358f06ef85bcb0"
+  dependencies:
+    lodash "3.8.0"
+
 require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -4428,6 +4456,12 @@ slice-ansi@0.0.4:
 slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+
+snake-case@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-2.1.0.tgz#41bdb1b73f30ec66a04d4e2cad1b76387d4d6d9f"
+  dependencies:
+    no-case "^2.2.0"
 
 sntp@1.x.x:
   version "1.0.9"


### PR DESCRIPTION
Went smoothly with the exception of two imports that the codemod doesn't know about:

* `Ember.RouterDSL` - It seems like this could be added to the dataset used to polyfill back to the old globals imports as [`@ember/routing` includes several other similar modules](https://github.com/ember-cli/ember-rfc176-data#emberrouting)
* `Ember._ProxyMixin` - This is private and therefore my understanding is it won't be included in the new modules api, but I'm not sure what this means in practice here