### PR TITLE
Make naming of testing modules consistent with Ember.js conventions

### DIFF
--- a/tests/acceptance/ember-init-test.js
+++ b/tests/acceptance/ember-init-test.js
@@ -14,7 +14,7 @@ function lookupFactory(app, key) {
 let toriiConfiguration = configuration.torii;
 var originalSessionServiceName;
 
-module('Ember Initialization - Acceptance', {
+module('Acceptance | Ember Initialization', {
   beforeEach() {
     originalSessionServiceName = toriiConfiguration.sessionServiceName;
     delete toriiConfiguration.sessionServiceName;

--- a/tests/acceptance/routing-test.js
+++ b/tests/acceptance/routing-test.js
@@ -10,7 +10,7 @@ let { module, test } = QUnit;
 let configuration = rawConfig.torii;
 var app, originalSessionServiceName;
 
-module('Routing - Acceptance', {
+module('Acceptance | Routing', {
   beforeEach() {
     originalSessionServiceName = configuration.sessionServiceName;
     delete configuration.sessionServiceName;

--- a/tests/acceptance/session-test.js
+++ b/tests/acceptance/session-test.js
@@ -11,7 +11,7 @@ function signIn(session, sessionData={}){
   sm.send('finishOpen', sessionData);
 }
 
-moduleForAcceptance('Session - Acceptance', {
+moduleForAcceptance('Acceptance | Session', {
   beforeEach() {
     this.container = this.application.__container__;
     this.torii   = this.container.lookup("service:torii");

--- a/tests/acceptance/torii-helper-test.js
+++ b/tests/acceptance/torii-helper-test.js
@@ -6,7 +6,7 @@ const { test } = QUnit;
 
 let container;
 
-moduleForAcceptance('Testing Helper - Acceptance', {
+moduleForAcceptance('Acceptance | Testing Helper', {
   beforeEach() {
     container = this.application.__container__;
   }

--- a/tests/integration/providers/azure-ad-oauth2-test.js
+++ b/tests/integration/providers/azure-ad-oauth2-test.js
@@ -12,7 +12,7 @@ var mockPopup = new MockPopup();
 
 var failPopup = new MockPopup({ state: 'invalid-state' });
 
-module('AzureAd - Integration', {
+module('Integration | Provider | AzureAd', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     app.register('torii-service:mock-popup', mockPopup, {instantiate: false});

--- a/tests/integration/providers/edmodo-connect-test.js
+++ b/tests/integration/providers/edmodo-connect-test.js
@@ -9,7 +9,7 @@ const { module, test } = QUnit;
 
 var opened, mockPopup;
 
-module('Edmodo Connect - Integration', {
+module('Integration | Provider | Edmodo Connect', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     mockPopup = {

--- a/tests/integration/providers/facebook-connect-test.js
+++ b/tests/integration/providers/facebook-connect-test.js
@@ -14,7 +14,7 @@ let providerConfiguration;
 
 var torii, app;
 
-module('Facebook Connect - Integration', {
+module('Integration | Provider | Facebook Connect', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     torii = lookup(app, 'service:torii');

--- a/tests/integration/providers/facebook-oauth2-test.js
+++ b/tests/integration/providers/facebook-oauth2-test.js
@@ -12,7 +12,7 @@ var mockPopup = new MockPopup();
 
 var failPopup = new MockPopup({ state: 'invalid-state' });
 
-module('Facebook OAuth2 - Integration', {
+module('Integration | Provider | Facebook OAuth2', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     app.register('torii-service:mock-popup', mockPopup, {instantiate: false});

--- a/tests/integration/providers/github-oauth2-test.js
+++ b/tests/integration/providers/github-oauth2-test.js
@@ -12,7 +12,7 @@ var mockPopup = new MockPopup();
 
 var failPopup = new MockPopup({ state: 'invalid-state' });
 
-module('Github - Integration', {
+module('Integration | Provider | Github', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     app.register('torii-service:mock-popup', mockPopup, {instantiate: false});

--- a/tests/integration/providers/google-oauth2-bearer-test.js
+++ b/tests/integration/providers/google-oauth2-bearer-test.js
@@ -9,7 +9,7 @@ const { module, test } = QUnit;
 
 var opened, mockPopup, providerConfig;
 
-module('Google Bearer- Integration', {
+module('Integration | Provider | Google Bearer', {
   beforeEach() {
     mockPopup = {
       open: function(){

--- a/tests/integration/providers/google-oauth2-test.js
+++ b/tests/integration/providers/google-oauth2-test.js
@@ -12,7 +12,7 @@ var mockPopup = new MockPopup();
 
 var failPopup = new MockPopup({ state: 'invalid-state' });
 
-module('Google - Integration', {
+module('Integration | Provider | Google', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     app.register('torii-service:mock-popup', mockPopup, {instantiate: false});

--- a/tests/integration/providers/linked-in-oauth2-test.js
+++ b/tests/integration/providers/linked-in-oauth2-test.js
@@ -12,7 +12,7 @@ var mockPopup = new MockPopup();
 
 var failPopup = new MockPopup({ state: 'invalid-state' });
 
-module('Linked In - Integration', {
+module('Integration | Provider | Linked In', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     app.register('torii-service:mock-popup', mockPopup, {instantiate: false});

--- a/tests/integration/providers/oauth1-test.js
+++ b/tests/integration/providers/oauth1-test.js
@@ -19,7 +19,7 @@ var opened, openedUrl, mockPopup = {
 var requestTokenUri = 'http://localhost:3000/oauth/callback';
 var providerName = 'oauth1';
 
-module('Oauth1 - Integration', {
+module('Integration | Provider | Oauth1', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     app.register('torii-service:mock-popup', mockPopup, {instantiate: false});

--- a/tests/integration/providers/stripe-connect-test.js
+++ b/tests/integration/providers/stripe-connect-test.js
@@ -12,7 +12,7 @@ var mockPopup = new MockPopup();
 
 var failPopup = new MockPopup({ state: 'invalid-state' });
 
-module('Stripe Connect - Integration', {
+module('Integration | Provider | Stripe Connect', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     app.register('torii-service:mock-popup', mockPopup, {instantiate: false});

--- a/tests/integration/session-test.js
+++ b/tests/integration/session-test.js
@@ -11,7 +11,7 @@ import QUnit from 'qunit';
 
 const { module, test } = QUnit;
 
-module('Session (open) - Integration', {
+module('Integration | Session (open)', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     app.register('service:session', SessionService);
@@ -71,7 +71,7 @@ test("failed auth sets isAuthenticated to false, sets error", function(assert){
   });
 });
 
-module('Session (close) - Integration', {
+module('Integration | Session (close) ', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     app.register('service:session', SessionService);

--- a/tests/integration/torii-test.js
+++ b/tests/integration/torii-test.js
@@ -8,7 +8,7 @@ import QUnit from 'qunit';
 
 let { module, test } = QUnit;
 
-module('Torii - Integration', {
+module('Integration | Torii', {
   beforeEach() {
     app = startApp({loadInitializers: true});
     app.register('torii-provider:dummy-success', DummySuccessProvider);

--- a/tests/unit/adapters/dummy-test.js
+++ b/tests/unit/adapters/dummy-test.js
@@ -4,7 +4,7 @@ let { module, test } = QUnit;
 
 var adapter;
 
-module("DummyAdapter - Unit", {
+module('Unit | Adapter | DummyAdapter', {
   beforeEach() {
     adapter = DummyAdapter.create();
   },

--- a/tests/unit/configuration-test.js
+++ b/tests/unit/configuration-test.js
@@ -14,7 +14,7 @@ var Testable = Ember.Object.extend({
     }),
     testable;
 
-module('Configuration - Unit', {
+module('Unit | Configuration', {
   beforeEach() {
     testable = Testable.create();
   },

--- a/tests/unit/lib/parse-query-string-test.js
+++ b/tests/unit/lib/parse-query-string-test.js
@@ -3,7 +3,7 @@ let { module, test } = QUnit;
 
 import ParseQueryString from 'torii/lib/parse-query-string';
 
-module('ParseQueryString - Unit');
+module('Unit | Lib | ParseQueryString');
 
 test('parses each passed key', function(assert){
   var url = 'http://localhost.dev:3000/xyz/?code=abcdef';

--- a/tests/unit/lib/popup-id-serializer-test.js
+++ b/tests/unit/lib/popup-id-serializer-test.js
@@ -3,7 +3,7 @@ import QUnit from 'qunit';
 
 let { module, test } = QUnit;
 
-module('PopupIdSerializer - Unit');
+module('Unit | Lib | PopupIdSerializer');
 
 test('.serialize prepends a prefix before the popup id', function(assert){
   var popupId = "abc12345";

--- a/tests/unit/lib/query-string-test.js
+++ b/tests/unit/lib/query-string-test.js
@@ -11,7 +11,7 @@ var obj,
     redirectUri = 'http://localhost.dev:3000/xyz/pdq',
     optionalProperty = 'i-am-optional';
 
-module('QueryString - Unit', {
+module('Unit | Lib | QueryString', {
   beforeEach() {
     obj = Ember.Object.create({
       clientId:         clientId,

--- a/tests/unit/lib/state-machine-test.js
+++ b/tests/unit/lib/state-machine-test.js
@@ -3,7 +3,7 @@ import QUnit from 'qunit';
 
 let { module, test } = QUnit;
 
-module('State Machine - Unit');
+module('Unit | Lib | State Machine');
 
 test("can transition from one state to another", function(assert){
   var sm = new StateMachine({

--- a/tests/unit/lib/uuid-generator-test.js
+++ b/tests/unit/lib/uuid-generator-test.js
@@ -3,7 +3,7 @@ import QUnit from 'qunit';
 
 let { module, test } = QUnit;
 
-module('UUIDGenerator - Unit');
+module('Unit | Lib | UUIDGenerator');
 
 test('exists', function(assert){
   assert.ok(UUIDGenerator);

--- a/tests/unit/providers/azure-ad-oauth2-test.js
+++ b/tests/unit/providers/azure-ad-oauth2-test.js
@@ -7,7 +7,7 @@ let { module, test } = QUnit;
 let provider;
 let originalConfiguration;
 
-module('Unit - AzureAdOAuth2Provider', {
+module('Unit | Provider | AzureAdOAuth2Provider', {
   beforeEach() {
     originalConfiguration = getConfiguration();
     configure({

--- a/tests/unit/providers/dummy-failure-test.js
+++ b/tests/unit/providers/dummy-failure-test.js
@@ -5,7 +5,7 @@ import QUnit from 'qunit';
 
 let { module, test } = QUnit;
 
-module('DummyFailureProvider - Unit', {
+module('Unit | Provider | DummyFailureProvider', {
   beforeEach() {
     provider = Provider.create();
   },

--- a/tests/unit/providers/dummy-success-test.js
+++ b/tests/unit/providers/dummy-success-test.js
@@ -5,7 +5,7 @@ import QUnit from 'qunit';
 
 let { module, test } = QUnit;
 
-module('DummySuccessProvider - Unit', {
+module('Unit | Provider | DummySuccessProvider', {
   beforeEach() {
     provider = Provider.create();
   },

--- a/tests/unit/providers/edmodo-connect-test.js
+++ b/tests/unit/providers/edmodo-connect-test.js
@@ -8,7 +8,7 @@ import QUnit from 'qunit';
 let { module, test } = QUnit;
 let originalConfiguration;
 
-module('Unit - EdmodoConnectProvider', {
+module('Unit | Provider | EdmodoConnectProvider', {
   beforeEach() {
     originalConfiguration = getConfiguration();
     configure({

--- a/tests/unit/providers/google-oauth2-bearer-test.js
+++ b/tests/unit/providers/google-oauth2-bearer-test.js
@@ -8,7 +8,7 @@ import QUnit from 'qunit';
 let { module, test } = QUnit;
 let originalConfiguration;
 
-module('Unit - GoogleAuth2BearerProvider', {
+module('Unit | Provider | GoogleAuth2BearerProvider', {
   beforeEach() {
     originalConfiguration = getConfiguration();
     configure({

--- a/tests/unit/providers/google-oauth2-test.js
+++ b/tests/unit/providers/google-oauth2-test.js
@@ -7,7 +7,7 @@ let { module, test } = QUnit;
 var provider;
 let originalConfiguration;
 
-module('Unit - GoogleAuth2Provider', {
+module('Unit | Provider | GoogleAuth2Provider', {
   beforeEach() {
     originalConfiguration = getConfiguration();
     configure({

--- a/tests/unit/providers/oauth1-test.js
+++ b/tests/unit/providers/oauth1-test.js
@@ -16,7 +16,7 @@ var Provider = BaseProvider.extend({
   redirectUri: 'http://foo'
 });
 
-module('MockOauth1Provider (oauth1 subclass) - Unit', {
+module('Unit | Provider | MockOauth1Provider (oauth1 subclass)', {
   beforeEach() {
     originalConfiguration = getConfiguration();
     configure({

--- a/tests/unit/providers/oauth2-bearer-test.js
+++ b/tests/unit/providers/oauth2-bearer-test.js
@@ -14,7 +14,7 @@ var Provider = BaseProvider.extend({
   responseParams: ['state', 'access_token']
 });
 
-module('MockOauth2Provider (oauth2-bearer subclass) - Unit', {
+module('Unit | Provider | MockOauth2Provider (oauth2-bearer subclass)', {
   beforeEach() {
     originalConfiguration = getConfiguration();
     configure({

--- a/tests/unit/providers/oauth2-code-test.js
+++ b/tests/unit/providers/oauth2-code-test.js
@@ -22,7 +22,7 @@ var TokenProvider = BaseProvider.extend({
   responseType: 'token_id'
 });
 
-module('MockOauth2Provider (oauth2-code subclass) - Unit', {
+module('Unit | Provider | MockOauth2Provider (oauth2-code subclass)', {
   beforeEach() {
     originalConfiguration = getConfiguration();
     configure({

--- a/tests/unit/providers/stripe-connect-test.js
+++ b/tests/unit/providers/stripe-connect-test.js
@@ -7,7 +7,7 @@ let provider;
 let originalConfiguration;
 
 
-module('Unit - StripeConnectProvider', {
+module('Unit | Provider | StripeConnectProvider', {
   beforeEach() {
     originalConfiguration = getConfiguration();
     configure({

--- a/tests/unit/redirect-handler-test.js
+++ b/tests/unit/redirect-handler-test.js
@@ -21,7 +21,7 @@ function buildMockWindow(windowName, url){
   };
 }
 
-module('RedirectHandler - Unit');
+module('Unit | RedirectHandler');
 
 test('exists', function(assert){
   assert.ok(RedirectHandler);

--- a/tests/unit/routing/application-route-mixin-test.js
+++ b/tests/unit/routing/application-route-mixin-test.js
@@ -5,7 +5,7 @@ import { configure, getConfiguration } from 'torii/configuration';
 let { module, test } = QUnit;
 let originalConfiguration;
 
-module('Application Route Mixin - Unit', {
+module('Unit | Routing | Application Route Mixin', {
   beforeEach() {
     originalConfiguration = getConfiguration();
     configure({

--- a/tests/unit/routing/authenticated-route-mixin-test.js
+++ b/tests/unit/routing/authenticated-route-mixin-test.js
@@ -5,7 +5,7 @@ import { configure, getConfiguration } from 'torii/configuration';
 let { module, test } = QUnit;
 let originalConfiguration;
 
-module('Authenticated Route Mixin - Unit', {
+module('Unit | Routing | Authenticated Route Mixin', {
   beforeEach() {
     originalConfiguration = getConfiguration();
     configure({
@@ -160,7 +160,7 @@ test('failed authentication causes accessDenied action to be sent with transitio
         return Ember.RSVP.reject();
       }
     },
-    
+
     accessDenied: function(transition) {
       sentTransition = transition;
     }

--- a/tests/unit/services/popup-test.js
+++ b/tests/unit/services/popup-test.js
@@ -34,7 +34,7 @@ var buildMockStorageEvent = function(popupId, redirectUrl){
   });
 };
 
-module("Popup - Unit", {
+module('Unit | Service | Popup', {
   beforeEach() {
     popup = Popup.create();
     localStorage.removeItem(CURRENT_REQUEST_KEY);

--- a/tests/unit/torii-test.js
+++ b/tests/unit/torii-test.js
@@ -3,7 +3,7 @@ import QUnit from 'qunit';
 
 let { module, test } = QUnit;
 
-module('Torii');
+module('Unit | Torii');
 
 test('exists', function(assert){
   assert.ok(Torii);


### PR DESCRIPTION
### Why
* Right now it's using a mix of e.g. `Unit - XXX` and `XXX - Unit`. This makes it hard to get an overview when viewing the tests in the browser.
* Using the Ember.js conventions makes it slightly easier for everyone I guess.

### What
e.g.

````
module('Popup - Unit')
````

becomes

````
module('Unit | Service | Popup')
````