### PR TITLE
Fix for removing iframe remotes for IE

### DIFF
--- a/addon/services/iframe.js
+++ b/addon/services/iframe.js
@@ -13,7 +13,13 @@ var Iframe = EmberObject.extend(Evented, UiServiceMixin, {
   },
 
   closeRemote() {
-    this.remote.remove();
+    var iframeParent = document.querySelector('.torii-iframe-placeholder');
+
+    if (this.remote.remove) {
+      this.remote.remove();
+    } else if (iframeParent) {
+      iframeParent.removeChild(this.remote);
+    }
   },
 
   pollRemote() {


### PR DESCRIPTION
**Problem:** IE11 doesn't support [the `ChildNode.remove()` method](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove). This creates errors when trying to remove iframes on IE11, specifically with the `closeRemote` function.

**Solution:** This PR checks for support of this method first. Unsupported browsers remove the DOM parent element as a workaround.