### PR TITLE
Default google-oauth2 redirectUri to static page

### DIFF
--- a/addon/providers/google-oauth2.js
+++ b/addon/providers/google-oauth2.js
@@ -24,8 +24,11 @@ var GoogleOauth2 = Oauth2.extend({
 
   approvalPrompt: configurable('approvalPrompt', 'auto'),
 
-  redirectUri: configurable('redirectUri',
-                            'http://localhost:8000/oauth2callback'),
+  redirectUri: configurable('redirectUri', function(){
+    // A hack that allows redirectUri to be configurable
+    // but default to the superclass
+    return this._super();
+  }),
 
   hd: configurable('hd', '')
 });


### PR DESCRIPTION
This brings the google-oauth2 provider more in line with, for example, the facebook-oauth2 provider, which defaults `redirectUri` to the static `/torii/redirect.html` page.

Copied straight from `facebook-oauth2`.