### PR TITLE
Allow versioning of Facebook OAuth2 API

### DIFF
--- a/addon/providers/facebook-oauth2.js
+++ b/addon/providers/facebook-oauth2.js
@@ -1,9 +1,23 @@
 import { configurable } from 'torii/configuration';
 import Oauth2 from 'torii/providers/oauth2-code';
+import { computed } from '@ember/object';
 
 export default Oauth2.extend({
   name:    'facebook-oauth2',
-  baseUrl: 'https://www.facebook.com/dialog/oauth',
+  baseUrl: computed('apiVersion', function() {
+    if (this.get('apiVersion')) {
+      // Facebook API version must be of shape 'vx.x'.
+      const FACEBOOK_API_VERSION_REGEX = /^v(\d)\.(\d)$/;
+
+      if (!FACEBOOK_API_VERSION_REGEX.test(this.get('apiVersion'))) {
+        throw new Error(`The Facebook API version must be of the shape 'vX.X'`);
+      }
+
+      return `https://www.facebook.com/${this.get('apiVersion')}/dialog/oauth`;
+    } else {
+      return `https://www.facebook.com/dialog/oauth`;
+    }
+  }),
 
   // Additional url params that this provider requires
   requiredUrlParams: ['display'],
@@ -11,6 +25,7 @@ export default Oauth2.extend({
   responseParams: ['code', 'state'],
 
   scope:        configurable('scope', 'email'),
+  apiVersion:   configurable('apiVersion', null),
 
   display: 'popup',
   redirectUri: configurable('redirectUri', function(){

--- a/tests/unit/providers/facebook-oauth2-test.js
+++ b/tests/unit/providers/facebook-oauth2-test.js
@@ -1,0 +1,67 @@
+import { run } from '@ember/runloop';
+import { getConfiguration, configure } from 'torii/configuration';
+
+import FacebookProvider from 'torii/providers/facebook-oauth2';
+import QUnit from 'qunit';
+
+let { module, test } = QUnit;
+var provider;
+let originalConfiguration;
+
+module('Unit | Provider | FacebookOAuth2Provider', {
+  beforeEach() {
+    originalConfiguration = getConfiguration();
+    configure({
+      providers: {
+        'facebook-oauth2': {}
+      }
+    });
+    provider = FacebookProvider.create();
+  },
+  afterEach() {
+    run(provider, 'destroy');
+    configure(originalConfiguration);
+  }
+});
+
+test("Provider generates an unversioned path if no API version is configured", function(assert){
+  configure({
+    providers: {
+      'facebook-oauth2': {
+        apiKey: 'abcdef'
+      }
+    }
+  });
+
+  assert.ok(provider.buildUrl().startsWith('https://www.facebook.com/dialog/oauth'));
+});
+
+test("Provider generates a versioned path if an API version is configured", function(assert){
+  configure({
+    providers: {
+      'facebook-oauth2': {
+        apiKey: 'abcdef',
+        apiVersion: 'v3.2'
+      }
+    }
+  });
+
+  assert.ok(provider.buildUrl().startsWith('https://www.facebook.com/v3.2/dialog/oauth'));
+});
+
+test("Throws an error if the version does not have the right shape", function(assert){
+  configure({
+    providers: {
+      'facebook-oauth2': {
+        apiKey: 'abcdef',
+        apiVersion: '3.2'
+      }
+    }
+  });
+
+  assert.throws(
+    function() {
+      provider.buildUrl();
+    }
+  );
+});


### PR DESCRIPTION
The [Facebook API docs](https://developers.facebook.com/docs/apps/versions#versioning) recommend to always make versioned calls:

> An unversioned call will always point to the oldest version still available at the top of the chart. This is currently v2.1, but after two years it'll be v2.2, then v2.3, etc.
> 
> Because of this, our recommendation is to always specify versions when making calls, where possible.

This is currently not possible in torii. This PR adds an optional configuration parameter `apiVersion` that can be used to specify the version to be used. There is an additional check to make sure that the parameter is of the right shape as it has to be something like `v3.2`.