### PR TITLE
[UPGRADE]: Linkedin deprecated API v1. Using v2 for authentication

### DIFF
--- a/addon/providers/linked-in-oauth2.js
+++ b/addon/providers/linked-in-oauth2.js
@@ -9,7 +9,7 @@ import { configurable } from 'torii/configuration';
  */
 var LinkedInOauth2 = Oauth2.extend({
   name:       'linked-in-oauth2',
-  baseUrl:    'https://www.linkedin.com/uas/oauth2/authorization',
+  baseUrl:    'https://www.linkedin.com/oauth/v2/authorization',
 
   responseParams: ['code', 'state'],
 


### PR DESCRIPTION
- [Linkedin - Developer Program Updates - Deprecation](https://engineering.linkedin.com/blog/2018/12/developer-program-updates)
- [Authorization Code Flow](https://docs.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin/context#step-2-request-an-authorization-code)