### PR TITLE
use `set` to make sure the context updates properly

### DIFF
--- a/addon/session/state-machine.js
+++ b/addon/session/state-machine.js
@@ -1,11 +1,12 @@
 import StateMachine from 'torii/lib/state-machine';
+import { set } from '@ember/object';
 
 var transitionTo = StateMachine.transitionTo;
 
 function copyProperties(data, target) {
   for (var key in data) {
     if (data.hasOwnProperty(key)) {
-      target[key] = data[key];
+      set(target, key, data[key]);
     }
   }
 }


### PR DESCRIPTION
This PR resolves the following problem with Ember Octane:

Context...
- with Ember Octane
- when rendering something like {{this.session.currentUser.name}}

I am able to...
- login successfully and see the name property update
- logout successfully and see the name property disappear
- login again (without refreshing the page) 🙅‍♂ my ember app grinds to a halt 🙅‍♂ 

> Error: Assertion Failed: You attempted to update [object Object].currentUser to "[object Object]", but it is being tracked by a tracking context, such as a template, computed property, or observer. In order to make sure the context updates properly, you must invalidate the property when updating it. You can mark the property as `@tracked`, or use `@ember/object#set` to do this.