### PR TITLE
Add a try catch to avoid issues for Facebook connect with FastBoot

### DIFF
--- a/addon/providers/-private/utils.js
+++ b/addon/providers/-private/utils.js
@@ -10,8 +10,12 @@ export function resetLoadScript() {
 
 export function loadScript(src) {
   if (alternativeLoadScript) { return alternativeLoadScript(src); }
-  let scriptTag = document.createElement('script');
-  let firstScriptTag = document.getElementsByTagName('script')[0];
-  scriptTag.src = src;
-  firstScriptTag.parentNode.insertBefore(scriptTag, firstScriptTag);
+  try {
+    let scriptTag = document.createElement('script');
+    let firstScriptTag = document.getElementsByTagName('script')[0];
+    scriptTag.src = src;
+    firstScriptTag.parentNode.insertBefore(scriptTag, firstScriptTag);
+  } catch(e) {
+    console.log(e);
+  }
 }


### PR DESCRIPTION
As discussed in https://github.com/Vestorly/torii/issues/423, there's an issue with FastBoot for Facebook Connect. This pull request aims to fix the issue with a simple try catch to avoid the error on the document that's not existing in the scope of FastBoot.

I hope this helps.